### PR TITLE
Add core block wizard & dashboard

### DIFF
--- a/web/app/blocks/page.tsx
+++ b/web/app/blocks/page.tsx
@@ -1,35 +1,108 @@
-//web/app/blocks/page.tsx
-
 "use client";
-
-import { Card } from "@/components/ui/Card";
-import { useSessionContext } from "@supabase/auth-helpers-react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useSessionContext } from "@supabase/auth-helpers-react";
+import Shell from "@/components/layouts/Shell";
+import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import BlockCard, { Block } from "@/components/blocks/BlockCard";
+import BlockCreateModal from "@/components/blocks/BlockCreateModal";
+import { fetchBlocks, createBlock, toggleAuto } from "@/lib/supabase/blocks";
 
 export default function BlocksPage() {
   const { session, isLoading } = useSessionContext();
   const router = useRouter();
+  const [blocks, setBlocks] = useState<Block[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [filter, setFilter] = useState<'all' | 'core'>('all');
 
   useEffect(() => {
     if (isLoading) return;
     if (!session) {
       localStorage.setItem("postLoginRedirect", window.location.pathname);
       router.replace("/login");
+      return;
     }
-  }, [isLoading, session, router]);
+    (async () => {
+      const { data } = await fetchBlocks(session.user.id, filter === 'core');
+      if (data) setBlocks(data as any);
+    })();
+  }, [session, isLoading, router, filter]);
+
+  async function handleCreate(data: {
+    type: string;
+    label: string;
+    content: string;
+    auto: boolean;
+  }) {
+    if (!session?.user) return;
+    setLoading(true);
+    const { data: created } = await createBlock({
+      user_id: session.user.id,
+      type: data.type,
+      label: data.label,
+      content: data.content,
+      update_policy: data.auto ? "auto" : "manual",
+      is_core_block: false,
+    });
+    if (created) setBlocks((b) => [created as Block, ...b]);
+    setLoading(false);
+  }
+
+  async function handleToggle(id: string, enable: boolean) {
+    await toggleAuto(id, enable);
+    setBlocks((b) =>
+      b.map((blk) =>
+        blk.id === id ? { ...blk, update_policy: enable ? "auto" : "manual" } : blk
+      )
+    );
+  }
 
   if (isLoading) return null;
 
   return (
-    <div className="max-w-4xl mx-auto space-y-6">
-      <h1 className="text-2xl font-bold">🧱 Context Blocks</h1>
-      <Card>
-        <p className="text-sm text-muted-foreground">
-          Modular context units like tone, audience, and positioning. These are the foundation of your strategy.
-        </p>
-      </Card>
-      {/* TODO: Render list of context_blocks here */}
-    </div>
+    <Shell>
+      <div className="max-w-4xl mx-auto space-y-6">
+        <div className="flex justify-between items-center">
+          <h1 className="text-2xl font-bold">🧱 Context Blocks</h1>
+          <div className="flex items-center space-x-2">
+            <Button
+              size="sm"
+              variant={filter === "all" ? "default" : "outline"}
+              onClick={() => setFilter("all")}
+            >
+              All
+            </Button>
+            <Button
+              size="sm"
+              variant={filter === "core" ? "default" : "outline"}
+              onClick={() => setFilter("core")}
+            >
+              Core
+            </Button>
+            <Button onClick={() => setShowModal(true)}>+ Create Block</Button>
+          </div>
+        </div>
+        <Card>
+          <p className="text-sm text-muted-foreground">
+            Modular context units like tone, audience and positioning.
+          </p>
+        </Card>
+        <div className="space-y-4">
+          {blocks
+            .filter((b) => (filter === "core" ? b.is_core_block : true))
+            .map((b) => (
+              <BlockCard key={b.id} block={b} onToggleAuto={handleToggle} />
+            ))}
+        </div>
+        {/* TODO: pending review queue and diff view */}
+        <BlockCreateModal
+          open={showModal}
+          onOpenChange={setShowModal}
+          onCreate={handleCreate}
+        />
+      </div>
+    </Shell>
   );
 }

--- a/web/app/blocks/setup/page.tsx
+++ b/web/app/blocks/setup/page.tsx
@@ -1,11 +1,72 @@
 "use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSessionContext } from "@supabase/auth-helpers-react";
+import Shell from "@/components/layouts/Shell";
+import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { LoadingOverlay } from "@/components/ui/LoadingOverlay";
+import CoreBlockForm from "@/components/blocks/CoreBlockForm";
+import { CORE_BLOCKS_SETUP } from "@/constants/coreBlocks";
+import { createBlock } from "@/lib/supabase/blocks";
 
-import React from "react";
-import BlockSetupShell from "@/components/blocks/setup/BlockSetupShell";
-
-/**
- * Blocks setup route - renders the step-by-step block creation shell.
- */
 export default function BlockSetupPage() {
-  return <BlockSetupShell />;
+  const { session, isLoading } = useSessionContext();
+  const router = useRouter();
+  const [step, setStep] = useState(0);
+  const [label, setLabel] = useState("");
+  const [content, setContent] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  if (isLoading) return null;
+  if (!session) {
+    router.replace("/login");
+    return null;
+  }
+
+  const stepInfo = CORE_BLOCKS_SETUP[step];
+
+  async function handleNext() {
+    setSaving(true);
+    await createBlock({
+      user_id: session.user.id,
+      type: stepInfo.type,
+      label,
+      content,
+      update_policy: "manual",
+      is_core_block: true, // mark as one of the required core blocks
+    });
+    setSaving(false);
+    setLabel("");
+    setContent("");
+    if (step + 1 < CORE_BLOCKS_SETUP.length) {
+      setStep(step + 1);
+    } else {
+      router.push("/blocks");
+    }
+  }
+
+  return (
+    <Shell>
+      <div className="max-w-xl mx-auto">
+        <Card className="relative space-y-6">
+          {saving && <LoadingOverlay message="Saving..." />}
+          <h2 className="text-xl font-semibold">{stepInfo.title}</h2>
+          <CoreBlockForm
+            title={stepInfo.title}
+            prompt={stepInfo.prompt}
+            label={label}
+            content={content}
+            onLabelChange={setLabel}
+            onContentChange={setContent}
+          />
+          <div className="flex justify-end">
+            <Button onClick={handleNext} disabled={saving}>
+              {step + 1 < CORE_BLOCKS_SETUP.length ? "Next" : "Finish"}
+            </Button>
+          </div>
+        </Card>
+      </div>
+    </Shell>
+  );
 }

--- a/web/components/blocks/BlockCard.tsx
+++ b/web/components/blocks/BlockCard.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+
+export interface Block {
+  id: string;
+  type: string;
+  label: string;
+  content: string;
+  update_policy: string;
+  is_core_block: boolean;
+}
+
+interface BlockCardProps {
+  block: Block;
+  onToggleAuto?: (id: string, enable: boolean) => void;
+}
+
+export default function BlockCard({ block, onToggleAuto }: BlockCardProps) {
+  return (
+    <Card className="space-y-2">
+      <div className="flex justify-between items-center">
+        <div className="text-sm font-medium">
+          {block.label}
+          <span className="ml-2 text-xs px-2 py-0.5 bg-primary/10 rounded">
+            {block.type}
+          </span>
+        </div>
+        {onToggleAuto && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => onToggleAuto(block.id, block.update_policy !== "auto")}
+          >
+            {block.update_policy === "auto" ? "Manual" : "Auto-update"}
+          </Button>
+        )}
+      </div>
+      <p className="text-sm text-muted-foreground">
+        {block.content.slice(0, 120)}
+        {block.content.length > 120 ? "…" : ""}
+      </p>
+    </Card>
+  );
+}

--- a/web/components/blocks/BlockCreateModal.tsx
+++ b/web/components/blocks/BlockCreateModal.tsx
@@ -1,0 +1,108 @@
+"use client";
+import { useState, useEffect } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { createClient } from "@/lib/supabaseClient";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onCreate: (data: {
+    type: string;
+    label: string;
+    content: string;
+    auto: boolean;
+  }) => Promise<void>;
+}
+
+export default function BlockCreateModal({ open, onOpenChange, onCreate }: Props) {
+  const [label, setLabel] = useState("");
+  const [content, setContent] = useState("");
+  const [blockTypes, setBlockTypes] = useState<string[]>([]);
+  const [type, setType] = useState("");
+  const [auto, setAuto] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const supabase = createClient();
+    supabase
+      .from("context_blocks")
+      .select("type")
+      .then(({ data }) => {
+        if (data) {
+          const vals = Array.from(new Set(data.map((d) => d.type))).sort();
+          setBlockTypes(vals);
+          if (!type) setType(vals[0] || "custom");
+        }
+      });
+  }, [open]);
+
+  async function handleSave() {
+    setSaving(true);
+    await onCreate({ type, label, content, auto });
+    setLabel("");
+    setContent("");
+    setAuto(true);
+    setType(blockTypes[0] || "custom");
+    setSaving(false);
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create Block</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-muted-foreground">Type</label>
+            <select
+              className="mt-1 w-full border rounded p-2"
+              value={type}
+              onChange={(e) => setType(e.target.value)}
+            >
+              {blockTypes.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-muted-foreground">Label</label>
+            <Input value={label} onChange={(e) => setLabel(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-muted-foreground">Content</label>
+            <textarea
+              className="mt-1 w-full border rounded p-2"
+              rows={6}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+            />
+          </div>
+          <div className="flex items-center space-x-2">
+            <input
+              id="auto-toggle"
+              type="checkbox"
+              className="h-4 w-4"
+              checked={auto}
+              onChange={(e) => setAuto(e.target.checked)}
+            />
+            <label htmlFor="auto-toggle" className="text-sm text-muted-foreground">
+              Auto-update
+            </label>
+          </div>
+        </div>
+        <DialogFooter className="pt-4">
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? "Saving..." : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/components/blocks/CoreBlockForm.tsx
+++ b/web/components/blocks/CoreBlockForm.tsx
@@ -1,0 +1,72 @@
+"use client";
+import { useState } from "react";
+import { Input } from "@/components/ui/Input";
+import { TextareaInline } from "@/components/TextareaInline";
+
+let z: any = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  z = require("zod");
+} catch {
+  // library missing
+}
+
+interface CoreBlockFormProps {
+  title: string;
+  prompt: string;
+  label: string;
+  content: string;
+  onLabelChange: (v: string) => void;
+  onContentChange: (v: string) => void;
+}
+
+export default function CoreBlockForm({
+  title,
+  prompt,
+  label,
+  content,
+  onLabelChange,
+  onContentChange,
+}: CoreBlockFormProps) {
+  const [errors, setErrors] = useState<{ label?: string; content?: string }>({});
+
+  function validate(l: string, c: string) {
+    if (!z) return {};
+    const schema = z.object({
+      label: z.string().min(1, "Required"),
+      content: z.string().min(1, "Required"),
+    });
+    const res = schema.safeParse({ label: l, content: c });
+    return res.success ? {} : res.error.flatten().fieldErrors;
+  }
+
+  function handleBlur() {
+    setErrors(validate(label, content));
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-muted-foreground">Label</label>
+        <Input
+          value={label}
+          onChange={(e) => onLabelChange(e.target.value)}
+          onBlur={handleBlur}
+        />
+        {errors.label && <p className="text-xs text-red-500">{errors.label}</p>}
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-muted-foreground">{title}</label>
+        <textarea
+          className="mt-1 w-full border rounded p-2"
+          rows={6}
+          placeholder={prompt}
+          value={content}
+          onBlur={handleBlur}
+          onChange={(e) => onContentChange(e.target.value)}
+        />
+        {errors.content && <p className="text-xs text-red-500">{errors.content}</p>}
+      </div>
+    </div>
+  );
+}

--- a/web/constants/coreBlocks.ts
+++ b/web/constants/coreBlocks.ts
@@ -1,0 +1,6 @@
+export const CORE_BLOCKS_SETUP = [
+  { type: "topic", title: "Topic", prompt: "Describe your main topic." },
+  { type: "intent", title: "Intent", prompt: "What is the primary intent?" },
+  { type: "reference", title: "Reference", prompt: "Provide any key references." },
+  { type: "style_guide", title: "Style Guide", prompt: "Outline your style guide." },
+];


### PR DESCRIPTION
## Summary
- add constant `CORE_BLOCKS_SETUP`
- build 4‑step onboarding wizard for core blocks
- show blocks dashboard with create modal
- expose `fetchBlocks`, `createBlock`, and `toggleAuto` helpers
- update composer and validator agents for new core types
- add filter for core blocks on blocks dashboard

## Test plan
- `make format` *(fails: hatchling build backend error)*
- `make lint` *(fails: hatchling build backend error)*
- `make tests` *(fails: hatchling build backend error)*


------
https://chatgpt.com/codex/tasks/task_e_6840eddd105c83298137e1b24b24acd4