### PR TITLE
add_agent_run_route_to_trigger_orch_block_manager_agent

### DIFF
--- a/api/src/app/agent_server.py
+++ b/api/src/app/agent_server.py
@@ -43,6 +43,7 @@ from .agent_tasks.layer2_tasks.utils.task_router import route_and_validate_task
 from .routes.task_types import router as task_types_router
 from .routes.task_brief import router as task_brief_router
 from .routes.baskets import router as basket_router
+from .routes.agent_run import router as agent_run_router
 
 # ── Environment variable for Bubble webhook URL
 CHAT_URL = os.getenv("BUBBLE_CHAT_URL")
@@ -78,6 +79,8 @@ app.include_router(task_types_router)
 app.include_router(task_brief_router)
 # Mount basket routes
 app.include_router(basket_router)
+# Agent-run proxy route
+app.include_router(agent_run_router)
 
 
 

--- a/api/src/app/routes/agent_run.py
+++ b/api/src/app/routes/agent_run.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, HTTPException
+from ..agent_tasks.layer1_infra.utils.supabase_helpers import get_supabase
+from ..agent_tasks.orchestration.thread_parser_listener import handle_update_basket
+
+router = APIRouter(tags=["agents"])
+
+@router.post("/agent-run", status_code=202)
+async def agent_run(payload: dict):
+    agent = payload.get("agent")
+    event = payload.get("event")
+    info = payload.get("input", {})
+
+    if agent != "orch_block_manager_agent":
+        raise HTTPException(status_code=400, detail="unsupported agent")
+
+    if event == "basket_inputs.created":
+        input_id = info.get("input_id")
+        if not input_id:
+            raise HTTPException(status_code=422, detail="input_id required")
+        supabase = get_supabase()
+        row = (
+            supabase.table("basket_inputs")
+            .select("basket_id, content, file_ids")
+            .eq("id", input_id)
+            .single()
+            .execute()
+        )
+        if row.error or not row.data:
+            raise HTTPException(status_code=404, detail="input not found")
+
+        await handle_update_basket(
+            row.data["basket_id"],
+            {"input_text": row.data["content"], "file_ids": row.data.get("file_ids") or []},
+        )
+        return {"status": "queued"}
+
+    raise HTTPException(status_code=400, detail="unsupported event")


### PR DESCRIPTION
## Summary
- add `/agent-run` API route
- include new router in FastAPI server

## Testing
- `make tests` *(fails: build backend returned an error)*

------
https://chatgpt.com/codex/tasks/task_e_6846cc7942e8832989a720c31b28dc22