### PR TITLE
Add global drag overlay with scoped drop zones

### DIFF
--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -4,9 +4,15 @@ import { useEffect, useState } from "react";
 import DumpArea from "@/components/ui/DumpArea";
 import BasketInputLog from "@/components/BasketInputLog"; // to be implemented
 import ParsedBlockList from "@/components/ParsedBlockList"; // to be implemented
+import { ScopedDropZone } from "@/components/drop/ScopedDropZone";
 
 export default function BasketWorkPage({ params }: any) {
   const [basket, setBasket] = useState<any>(null);
+
+  const handleFileDrop = (files: File[]) => {
+    console.log("\ud83d\udcbe Basket Work dropped files:", files);
+    // TODO: Route files to thread or chat upload system
+  };
 
   useEffect(() => {
     const fetchBasket = async () => {
@@ -22,7 +28,8 @@ export default function BasketWorkPage({ params }: any) {
   if (!basket) return <p className="p-4">Loading…</p>;
 
   return (
-    <div className="p-6 space-y-8 max-w-5xl mx-auto">
+    <ScopedDropZone onFilesDropped={handleFileDrop}>
+      <div className="p-6 space-y-8 max-w-5xl mx-auto">
       <div>
         <h1 className="text-2xl font-bold">🧶 {basket.intent_summary || "Untitled Basket"}</h1>
         <p className="text-sm text-muted-foreground mt-1">
@@ -48,5 +55,6 @@ export default function BasketWorkPage({ params }: any) {
         <ParsedBlockList basketId={params.id} />
       </section>
     </div>
+    </ScopedDropZone>
   );
 }

--- a/web/app/baskets/create/page.tsx
+++ b/web/app/baskets/create/page.tsx
@@ -6,12 +6,18 @@ import { Button } from "@/components/ui/Button";
 import { useRouter } from "next/navigation";
 import { createBasketWithInput } from "@/lib/baskets/createBasketWithInput";
 import { toast } from "react-hot-toast";
+import { ScopedDropZone } from "@/components/drop/ScopedDropZone";
 
 export default function BasketCreatePage() {
   const [text, setText] = useState("");
   const [files, setFiles] = useState<(File | string)[]>([]);
   const [loading, setLoading] = useState(false);
   const router = useRouter();
+
+  const handleFileDrop = (files: File[]) => {
+    console.log("\ud83d\udcbe Basket Create dropped files:", files);
+    // TODO: Route files to UploadArea or task context
+  };
 
   const handleSubmit = async () => {
     if (!text.trim() && files.length === 0) {
@@ -31,7 +37,8 @@ export default function BasketCreatePage() {
   };
 
   return (
-    <main className="p-6 max-w-4xl mx-auto space-y-6">
+    <ScopedDropZone onFilesDropped={handleFileDrop}>
+      <main className="p-6 max-w-4xl mx-auto space-y-6">
       <div className="space-y-1">
         <h1 className="text-2xl font-semibold tracking-tight">🧠 Dump your thoughts here</h1>
         <p className="text-muted-foreground">Paste chats and upload reference files.</p>
@@ -49,5 +56,6 @@ export default function BasketCreatePage() {
         </Button>
       </div>
     </main>
+    </ScopedDropZone>
   );
 }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono, Pacifico } from "next/font/google";
 import "./globals.css";
 import SupabaseProvider from "@/components/SupabaseProvider";
 import { Toaster } from "react-hot-toast";
+import AppLayout from "@/components/layout/AppLayout";
 
 // Font setup
 const geistSans = Geist({
@@ -41,7 +42,9 @@ export default function RootLayout({
       className={`${geistSans?.variable || ""} ${geistMono?.variable || ""} ${pacifico?.variable || ""}`}
     >
       <body className="antialiased min-h-screen">
-        <SupabaseProvider>{children}</SupabaseProvider>
+        <AppLayout>
+          <SupabaseProvider>{children}</SupabaseProvider>
+        </AppLayout>
         <Toaster position="top-right" />
       </body>
     </html>

--- a/web/components/FileDropOverlay.tsx
+++ b/web/components/FileDropOverlay.tsx
@@ -1,0 +1,9 @@
+export function FileDropOverlay({ isVisible }: { isVisible: boolean }) {
+  if (!isVisible) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm pointer-events-none">
+      <div className="text-white text-xl font-medium">📁 Drop your files anywhere</div>
+    </div>
+  );
+}

--- a/web/components/drop/ScopedDropZone.tsx
+++ b/web/components/drop/ScopedDropZone.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+interface Props {
+  children: React.ReactNode;
+  onFilesDropped: (files: File[]) => void;
+}
+
+export function ScopedDropZone({ children, onFilesDropped }: Props) {
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const files = Array.from(e.dataTransfer.files || []);
+    if (files.length > 0) onFilesDropped(files);
+  };
+
+  return (
+    <div onDrop={handleDrop} onDragOver={(e) => e.preventDefault()}>
+      {children}
+    </div>
+  );
+}

--- a/web/components/layout/AppLayout.tsx
+++ b/web/components/layout/AppLayout.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { ReactNode } from "react";
+import { useFileDrag } from "@/hooks/useFileDrag";
+import { FileDropOverlay } from "@/components/FileDropOverlay";
+
+export default function AppLayout({ children }: { children: ReactNode }) {
+  const { isDraggingFile } = useFileDrag();
+
+  function noopDropHandler(e: React.DragEvent) {
+    e.preventDefault();
+    // Intentionally does nothing — actual drop logic must be scoped
+  }
+
+  return (
+    <div onDrop={noopDropHandler} onDragOver={(e) => e.preventDefault()}>
+      <FileDropOverlay isVisible={isDraggingFile} />
+      {children}
+    </div>
+  );
+}

--- a/web/hooks/useFileDrag.ts
+++ b/web/hooks/useFileDrag.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+
+export function useFileDrag() {
+  const [isDraggingFile, setIsDraggingFile] = useState(false);
+
+  useEffect(() => {
+    let dragCounter = 0;
+
+    function onDragEnter(e: DragEvent) {
+      if (e.dataTransfer?.items?.[0]?.kind === "file") {
+        dragCounter++;
+        setIsDraggingFile(true);
+      }
+    }
+
+    function onDragLeave() {
+      dragCounter--;
+      if (dragCounter === 0) setIsDraggingFile(false);
+    }
+
+    function onDrop() {
+      dragCounter = 0;
+      setIsDraggingFile(false);
+    }
+
+    window.addEventListener("dragenter", onDragEnter);
+    window.addEventListener("dragleave", onDragLeave);
+    window.addEventListener("drop", onDrop);
+
+    return () => {
+      window.removeEventListener("dragenter", onDragEnter);
+      window.removeEventListener("dragleave", onDragLeave);
+      window.removeEventListener("drop", onDrop);
+    };
+  }, []);
+
+  return { isDraggingFile };
+}


### PR DESCRIPTION
## Summary
- implement `useFileDrag` hook for drag state tracking
- create `FileDropOverlay` component
- add `ScopedDropZone` for localized drop handling
- wrap app with new `AppLayout` to show overlay and prevent default drops
- enable scoped drop zones on basket create & work pages

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run e2e:test` *(fails: web server permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6847d6a1902483298bb77d41e1b4d5c7