### PR TITLE
Fix utils import paths

### DIFF
--- a/api/src/app/agent_tasks/layer2_tasks/utils/task_utils.py
+++ b/api/src/app/agent_tasks/layer2_tasks/utils/task_utils.py
@@ -5,7 +5,7 @@ import uuid
 
 from supabase import Client, create_client
 
-from ....utils.db import json_safe
+from src.utils.db import json_safe
 
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")

--- a/api/src/app/routes/baskets.py
+++ b/api/src/app/routes/baskets.py
@@ -9,7 +9,7 @@ from schemas.context_block import ContextBlock
 
 from ..agent_tasks.layer1_infra.utils.supabase_helpers import get_supabase
 from ..supabase_helpers import publish_event
-from ..utils.db import json_safe
+from src.utils.db import json_safe
 
 router = APIRouter(prefix="/baskets", tags=["baskets"])
 

--- a/api/src/app/routes/task_brief.py
+++ b/api/src/app/routes/task_brief.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from ..agent_tasks.layer1_infra.utils.supabase_helpers import get_supabase
-from ..utils.db import json_safe
+from src.utils.db import json_safe
 
 router = APIRouter(prefix="/task-brief", tags=["task-brief"])
 

--- a/api/src/utils/__init__.py
+++ b/api/src/utils/__init__.py
@@ -1,0 +1,4 @@
+from .db import json_safe
+from .supabase_client import supabase_client
+
+__all__ = ["json_safe", "supabase_client"]

--- a/api/src/utils/supabase_client.py
+++ b/api/src/utils/supabase_client.py
@@ -1,0 +1,7 @@
+from os import getenv
+from supabase import create_client
+
+SUPABASE_URL = getenv("SUPABASE_URL")
+SUPABASE_SERVICE_ROLE_KEY = getenv("SUPABASE_SERVICE_ROLE_KEY")
+
+supabase_client = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)


### PR DESCRIPTION
## Summary
- use absolute `src.utils` imports
- centralize supabase client
- expose helpers via `src.utils`

## Testing
- `uv run ruff check` *(fails: build backend error)*
- `uv run pytest` *(fails: build backend error)*
- `uvicorn src.app.agent_server:app --host 0.0.0.0 --port 8000` *(fails: ModuleNotFoundError: No module named 'supabase')*

------
https://chatgpt.com/codex/tasks/task_e_6849324afa288329b66f94a2f8fa82be