### PR TITLE
Fix utils import paths

### DIFF
--- a/api/src/app/agent_entrypoints.py
+++ b/api/src/app/agent_entrypoints.py
@@ -22,7 +22,7 @@ from .agent_tasks.layer2_tasks.utils.task_router import route_and_validate_task
 from .agent_tasks.layer2_tasks.utils.task_utils import create_task_and_session
 from .agent_tasks.layer3_config.adapters.google_exporter import export_to_doc
 from .agent_tasks.layer3_config.utils.config_to_md import render_markdown
-from .utils.db import json_safe
+from src.utils.db import json_safe
 
 router = APIRouter()
 

--- a/api/src/app/agent_tasks/layer1_infra/agents/infra_analyzer_agent.py
+++ b/api/src/app/agent_tasks/layer1_infra/agents/infra_analyzer_agent.py
@@ -10,7 +10,7 @@ from app.event_bus import DB_URL  # reuse same URL
 from app.supabase_helpers import publish_event
 
 from ..schemas import AuditReport, DuplicateLabel
-from ..utils.block_policy import insert_revision, is_auto
+from src.app.agent_tasks.layer1_infra.utils.block_policy import insert_revision, is_auto
 
 DUPLICATE_CHECK_SQL = """
 with dupes as (

--- a/api/src/app/agent_tasks/layer1_infra/agents/infra_research_agent.py
+++ b/api/src/app/agent_tasks/layer1_infra/agents/infra_research_agent.py
@@ -11,7 +11,7 @@ from app.event_bus import DB_URL
 from app.supabase_helpers import publish_event
 
 from ..schemas import RefreshReport
-from ..utils.block_policy import insert_revision, is_auto
+from src.app.agent_tasks.layer1_infra.utils.block_policy import insert_revision, is_auto
 
 FIND_REFRESHABLE_SQL = """
 select id::text

--- a/api/src/app/agent_tasks/layer2_tasks/utils/task_utils.py
+++ b/api/src/app/agent_tasks/layer2_tasks/utils/task_utils.py
@@ -5,7 +5,7 @@ import uuid
 
 from supabase import Client, create_client
 
-from ....utils.db import json_safe
+from src.utils.db import json_safe
 
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")

--- a/api/src/app/agent_tasks/layer3_config/adapters/google_exporter.py
+++ b/api/src/app/agent_tasks/layer3_config/adapters/google_exporter.py
@@ -6,7 +6,7 @@ from utils.logged_agent import logged
 
 from app.integrations.google_client import DOCS_ENDPOINT, refresh_token
 
-from ..utils.config_to_md import render_markdown
+from src.app.agent_tasks.layer3_config.utils.config_to_md import render_markdown
 
 
 @logged("google_exporter")

--- a/api/src/app/routes/baskets.py
+++ b/api/src/app/routes/baskets.py
@@ -9,7 +9,7 @@ from schemas.context_block import ContextBlock
 
 from ..agent_tasks.layer1_infra.utils.supabase_helpers import get_supabase
 from ..supabase_helpers import publish_event
-from ..utils.db import json_safe
+from src.utils.db import json_safe
 
 router = APIRouter(prefix="/baskets", tags=["baskets"])
 

--- a/api/src/app/routes/task_brief.py
+++ b/api/src/app/routes/task_brief.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from ..agent_tasks.layer1_infra.utils.supabase_helpers import get_supabase
-from ..utils.db import json_safe
+from src.utils.db import json_safe
 
 router = APIRouter(prefix="/task-brief", tags=["task-brief"])
 

--- a/api/src/utils/__init__.py
+++ b/api/src/utils/__init__.py
@@ -1,0 +1,4 @@
+from .db import json_safe
+from .supabase_client import supabase_client
+
+__all__ = ["json_safe", "supabase_client"]

--- a/api/src/utils/supabase_client.py
+++ b/api/src/utils/supabase_client.py
@@ -1,0 +1,7 @@
+from os import getenv
+from supabase import create_client
+
+SUPABASE_URL = getenv("SUPABASE_URL")
+SUPABASE_SERVICE_ROLE_KEY = getenv("SUPABASE_SERVICE_ROLE_KEY")
+
+supabase_client = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ dev = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/app"]                    # ← path updated
 


### PR DESCRIPTION
## Summary
- use absolute `src.utils` imports
- centralize supabase client
- expose helpers via `src.utils`
- allow hatch build to use direct git dependencies

## Testing
- `uv run pytest -q` *(fails: TypeError in tests)*
- `env PYTHONPATH=api .venv/bin/uvicorn src.app.agent_server:app --host 0.0.0.0 --port 8000` *(fails: SupabaseException: supabase_key is required)*

------
https://chatgpt.com/codex/tasks/task_e_6849324afa288329b66f94a2f8fa82be