### PR TITLE
Refactor basket dump flow to SmartDrop

### DIFF
--- a/tests/basket-create.spec.ts
+++ b/tests/basket-create.spec.ts
@@ -1,14 +1,11 @@
 import { test, expect } from '@playwright/test';
 
-test('Create a new basket from dump', async ({ page }) => {
-  await page.goto('/baskets/new');
+test('Create basket from SmartDrop text', async ({ page }) => {
+  await page.goto('/baskets/create');
 
-  await page.fill('textarea[placeholder="What’s the idea or intent?"]', 'Run a playful Gen Z TikTok challenge');
-  await page.fill('textarea[placeholder="Add extra insights…"]', 'Lean into visual humor and cultural slang');
+  await page.getByPlaceholder('Drop it').fill('Run a 7-day launch');
+  await page.keyboard.press('Meta+Enter');
 
-  await page.click('button:has-text("Create")');
-  await page.waitForURL('**/baskets/**');
-
-  const heading = await page.locator('h1');
-  await expect(heading).toContainText('Run a playful Gen Z TikTok challenge');
+  await page.waitForURL('**/work');
+  await expect(page.url()).toContain('/work');
 });

--- a/tests/baskets/create_basket_and_blocks.spec.ts
+++ b/tests/baskets/create_basket_and_blocks.spec.ts
@@ -9,42 +9,15 @@ test.describe('Basket Creation Flow', () => {
     await page.goto('http://localhost:3000/baskets/create');
 
     // Fill in raw text dump
-    await page.getByLabel('Raw Text Dump').fill(
+    await page.getByPlaceholder('Drop it').fill(
       `Slide 1 – Dump, Memory, Brief\n\nPaste GPT replies here to structure them later.`
     );
-
-    // Optionally upload a file (safely skip if file doesn't exist)
-    const testFilePath = 'tests/assets/test-image.png';
-    try {
-      if (fs.existsSync(testFilePath)) {
-        const [fileChooser] = await Promise.all([
-          page.waitForEvent('filechooser'),
-          page.getByText('Drag & drop files here or click to upload').click(),
-        ]);
-        await fileChooser.setFiles(testFilePath);
-      } else {
-        console.warn(`⚠️ File not found at ${testFilePath}. Upload skipped.`);
-      }
-    } catch (err) {
-      console.warn(`⚠️ File upload error: ${(err as Error).message}`);
-    }
-
-    // Try filling the link using label or placeholder fallback
-    try {
-      await page.getByLabel('Relevant Links').fill('https://example.com/context');
-    } catch {
-      try {
-        await page.getByPlaceholder('Paste links here').fill('https://example.com/context');
-      } catch (innerErr) {
-        console.warn(`⚠️ Could not find link input by label or placeholder.`);
-      }
-    }
 
     // Optional: pause browser to debug manually
     // await page.pause();
 
     // Submit the basket creation form
-    await page.getByRole('button', { name: 'Create Basket' }).click();
+    await page.getByRole('button', { name: 'Save to Basket' }).click();
 
     // Wait for redirect to /baskets/[id]/work
     await page.waitForURL('**/baskets/*/work', { timeout: 5000 });

--- a/tests/baskets/dump_hotkey.spec.ts
+++ b/tests/baskets/dump_hotkey.spec.ts
@@ -8,7 +8,7 @@ test('open dump modal with hotkey', async ({ page }) => {
   await page.goto('/baskets/1/work');
   await page.keyboard.press(`${modifier}+Shift+V`);
   await expect(page.getByRole('dialog')).toBeVisible();
-  await page.getByLabel('Raw Text Dump').fill('hotkey text');
-  await page.getByRole('button', { name: /create basket|add dump/i }).click();
+  await page.getByPlaceholder('Drop it').fill('hotkey text');
+  await page.getByRole('button', { name: /save to basket/i }).click();
   await expect(page.locator('text=Dump added')).toBeVisible();
 });

--- a/web/components/DumpModal.tsx
+++ b/web/components/DumpModal.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState } from "react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Card, CardContent } from "@/components/ui/Card";
-import DumpArea from "@/components/ui/DumpArea";
+import SmartDropZone from "@/components/SmartDropZone";
+import ThumbnailStrip from "@/components/ThumbnailStrip";
 import { Button } from "@/components/ui/Button";
 import { createBasketWithInput } from "@/lib/baskets/createBasketWithInput";
 import { createDump } from "@/lib/baskets/createDump";
@@ -22,7 +23,7 @@ export default function DumpModal({ basketId: propBasketId, initialOpen = false 
   const [open, setOpen] = useState(initialOpen);
   const [basketId, setBasketId] = useState<string | null>(propBasketId ?? null);
   const [text, setText] = useState("");
-  const [files, setFiles] = useState<(File | string)[]>([]);
+  const [images, setImages] = useState<File[]>([]);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => setOpen(initialOpen), [initialOpen]);
@@ -39,23 +40,23 @@ export default function DumpModal({ basketId: propBasketId, initialOpen = false 
   }, []);
 
   const handleSubmit = async () => {
-    if (!text.trim() && files.length === 0) {
+    if (!text.trim() && images.length === 0) {
       toast.error("Please provide some content for the dump");
       return;
     }
     setLoading(true);
     try {
       if (basketId) {
-        await createDump({ basketId, text, files });
+        await createDump({ basketId, text, images });
         toast.success("Dump added");
       } else {
-        const basket = await createBasketWithInput({ text, files });
+        const basket = await createBasketWithInput({ text, files: images });
         toast.success("Basket created");
         window.location.href = `/baskets/${basket.id}/work`;
       }
       setOpen(false);
       setText("");
-      setFiles([]);
+      setImages([]);
     } catch (err) {
       console.error(err);
       toast.error("Failed to save dump");
@@ -68,13 +69,22 @@ export default function DumpModal({ basketId: propBasketId, initialOpen = false 
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent>
         <Card className="max-w-2xl p-8 mx-auto">
-          <CardContent className="space-y-6 p-0">
-            <h1 className="text-2xl font-semibold">What are we working on?</h1>
-            <DumpArea text={text} onTextChange={setText} onFilesChange={setFiles} />
+          <CardContent className="space-y-4 p-0">
+            <h2 className="text-xl font-medium">Drop it. We’ll remember.</h2>
+            <p className="text-xs text-muted-foreground">
+              Paste or drag text / screenshots. • Shortcut ⌘/Ctrl + Shift + V
+            </p>
+            <SmartDropZone
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              onImages={(f) => setImages((prev) => [...prev, ...f])}
+              rows={5}
+            />
+            {images.length > 0 && <ThumbnailStrip files={images} />}
             <div className="flex justify-end space-x-2 pt-4">
               <Button variant="ghost" onClick={() => setOpen(false)}>Cancel</Button>
               <Button onClick={handleSubmit} disabled={loading}>
-                {loading ? (basketId ? "Adding…" : "Creating…") : basketId ? "Add Dump" : "Create Basket"}
+                {loading ? (basketId ? "Adding…" : "Creating…") : "Save to Basket ↵"}
               </Button>
             </div>
           </CardContent>

--- a/web/components/SmartDropZone.tsx
+++ b/web/components/SmartDropZone.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { Textarea } from "@/components/ui/Textarea";
+import React from "react";
+
+interface SmartDropZoneProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  onImages?: (files: File[]) => void;
+}
+
+export default function SmartDropZone({
+  onImages,
+  onPaste,
+  onDrop,
+  ...props
+}: SmartDropZoneProps) {
+  const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = Array.from(e.clipboardData.items || []);
+    const files = items
+      .map((it) => (it.kind === "file" ? it.getAsFile() : null))
+      .filter((f): f is File => !!f && f.type.startsWith("image/"));
+    if (files.length) onImages?.(files);
+    onPaste?.(e);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLTextAreaElement>) => {
+    const files = Array.from(e.dataTransfer.files || []).filter((f) =>
+      f.type.startsWith("image/")
+    );
+    if (files.length) onImages?.(files);
+    onDrop?.(e);
+  };
+
+  return (
+    <Textarea
+      placeholder="Drop it"
+      onPaste={handlePaste}
+      onDrop={handleDrop}
+      onDragOver={(e) => e.preventDefault()}
+      {...props}
+    />
+  );
+}

--- a/web/components/ThumbnailStrip.tsx
+++ b/web/components/ThumbnailStrip.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { useEffect, useState } from "react";
+
+interface Props {
+  files: File[];
+}
+
+export default function ThumbnailStrip({ files }: Props) {
+  const [urls, setUrls] = useState<string[]>([]);
+
+  useEffect(() => {
+    const next = files.map((f) => URL.createObjectURL(f));
+    setUrls(next);
+    return () => {
+      next.forEach((u) => URL.revokeObjectURL(u));
+    };
+  }, [files]);
+
+  if (files.length === 0) return null;
+
+  return (
+    <div className="flex gap-2 mt-2">
+      {urls.map((u, idx) => (
+        <div key={idx} className="relative w-20 h-20 rounded overflow-hidden border bg-muted">
+          <img src={u} alt="preview" className="object-cover w-full h-full" />
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `SmartDropZone` for paste & drop capture
- preview dropped images with `ThumbnailStrip`
- streamline `DumpModal` to new SmartDrop UX
- upload pasted images via updated `createDump`
- adjust Playwright tests for SmartDrop
- remove binary test assets

## Testing
- `npm run lint`
- `npm test`
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_684a1df28edc832981a47ac509c27b9b