### PR TITLE
Finalize baskets responsive layout

### DIFF
--- a/web/app/baskets/[id]/layout.tsx
+++ b/web/app/baskets/[id]/layout.tsx
@@ -1,5 +1,4 @@
 import { BasketProvider } from "@/lib/context/BasketContext";
-import Shell from "@/components/layouts/Shell";
 
 export default async function BasketLayout({
   children,
@@ -10,8 +9,6 @@ export default async function BasketLayout({
 }) {
   const { id } = await params;
   return (
-    <BasketProvider initialId={id}>
-      <Shell>{children}</Shell>
-    </BasketProvider>
+    <BasketProvider initialId={id}>{children}</BasketProvider>
   );
 }

--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -29,7 +29,7 @@ export default function BasketWorkPage({ params }: any) {
 
   return (
     <ScopedDropZone onFilesDropped={handleFileDrop}>
-      <div className="p-6 space-y-8 max-w-5xl mx-auto">
+      <div className="max-w-2xl mx-auto p-4 space-y-8">
       <div>
         <h1 className="text-2xl font-bold">🧶 {basket.intent_summary || "Untitled Basket"}</h1>
         <p className="text-sm text-muted-foreground mt-1">

--- a/web/app/baskets/page.tsx
+++ b/web/app/baskets/page.tsx
@@ -49,15 +49,15 @@ export default function BasketsPage() {
   const pageData = filtered.slice((page - 1) * pageSize, page * pageSize);
 
   return (
-    <div className="p-6 space-y-6">
-      <div className="flex justify-between items-start flex-wrap gap-4">
-        <div>
+    <div className="p-4 space-y-6">
+      <div className="max-w-screen-xl mx-auto px-4 flex flex-col md:flex-row justify-between items-center gap-4">
+        <div className="space-y-1">
           <h1 className="text-2xl font-bold">🧺 My Baskets</h1>
           <p className="text-sm text-muted-foreground">
             Lightweight containers for your tasks, context, and thoughts
           </p>
         </div>
-        <div className="flex flex-wrap gap-2 items-center">
+        <div className="flex flex-col sm:flex-row flex-wrap gap-2 items-center">
           <Button asChild>
             <Link href="/baskets/create">+ Create Basket</Link>
           </Button>
@@ -92,9 +92,11 @@ export default function BasketsPage() {
           }
         />
       ) : (
-        <div className="grid gap-4 md:grid-cols-2">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-4 justify-center">
           {pageData.map((b) => (
-            <BasketCard key={b.id} basket={b} />
+            <div key={b.id} className="max-w-[680px] w-full mx-auto">
+              <BasketCard basket={b} />
+            </div>
           ))}
         </div>
       )}

--- a/web/app/components/layout/Sidebar.tsx
+++ b/web/app/components/layout/Sidebar.tsx
@@ -15,7 +15,14 @@ const baseItems = [
   { href: "/blocks", label: "◾ Blocks" }, // 🧩 Moved here
 ];
 
-const Sidebar = () => {
+import { X } from "lucide-react";
+
+interface SidebarProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const Sidebar = ({ open, onClose }: SidebarProps) => {
   const pathname = usePathname();
   const router = useRouter();
   const supabase = createClient();
@@ -31,14 +38,20 @@ const Sidebar = () => {
   };
 
   return (
-    <>
-      {/* Sidebar */}
-      <aside
-        className={clsx(
-          "fixed top-0 left-0 z-40 h-screen w-64 max-w-[80%] bg-background/90 backdrop-blur-md border-r border-border shadow-md md:relative md:block md:min-h-screen"
-        )}
+    <aside
+      className={clsx(
+        "fixed top-0 left-0 z-50 h-screen w-64 bg-background border-r border-border shadow-md transform transition-transform md:relative md:translate-x-0 md:block md:min-h-screen",
+        open ? "translate-x-0" : "-translate-x-full md:translate-x-0"
+      )}
+    >
+      <button
+        className="absolute top-3 left-3 md:hidden p-1 rounded-md hover:bg-muted"
+        onClick={onClose}
+        aria-label="Close sidebar"
       >
-        <div className="h-full flex flex-col justify-between py-6 px-4">
+        <X className="h-5 w-5" />
+      </button>
+      <div className="h-full flex flex-col justify-between py-6 px-4">
           {/* Top: Brand + Nav */}
           <div className="space-y-6">
             <div className="font-brand text-xl tracking-tight pb-2 mb-2 border-b border-border">yarnnn</div>
@@ -76,8 +89,7 @@ const Sidebar = () => {
             )}
           </div>
         </div>
-      </aside>
-    </>
+    </aside>
   );
 };
 

--- a/web/components/MobileSidebarToggle.tsx
+++ b/web/components/MobileSidebarToggle.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { Menu } from "lucide-react";
+
+export default function MobileSidebarToggle({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="md:hidden p-2 rounded-md border border-border bg-background"
+      aria-label="Open sidebar"
+    >
+      <Menu className="h-5 w-5" />
+    </button>
+  );
+}

--- a/web/components/layouts/Shell.tsx
+++ b/web/components/layouts/Shell.tsx
@@ -1,16 +1,39 @@
 "use client";
-import React, { ReactNode } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import Sidebar from "@/app/components/layout/Sidebar";
+import MobileSidebarToggle from "@/components/MobileSidebarToggle";
 
 interface ShellProps {
     children: ReactNode;
 }
 
 export default function Shell({ children }: ShellProps) {
+    const [open, setOpen] = useState(false);
+
+    useEffect(() => {
+        const handleEsc = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setOpen(false);
+        };
+        window.addEventListener("keydown", handleEsc);
+        return () => window.removeEventListener("keydown", handleEsc);
+    }, []);
+
     return (
         <div className="min-h-screen md:grid md:grid-cols-[16rem_1fr]">
-            <Sidebar />
-            <main className="p-6">{children}</main>
+            {/* Mobile overlay */}
+            {open && (
+                <div
+                    className="fixed inset-0 z-40 bg-black/50 md:hidden"
+                    onClick={() => setOpen(false)}
+                />
+            )}
+            <Sidebar open={open} onClose={() => setOpen(false)} />
+            <main className="p-6">
+                <div className="mb-4 md:hidden">
+                    <MobileSidebarToggle onClick={() => setOpen(true)} />
+                </div>
+                {children}
+            </main>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add mobile sidebar toggle component
- make sidebar collapsible with overlay
- cleanup nested layouts for basket work page
- improve baskets header spacing and card grid
- tighten basket work page main container

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684a56069e088329a89754359503d28a