### PR TITLE
Expose /blocks endpoint and API base prefix

### DIFF
--- a/api/src/app/agent_server.py
+++ b/api/src/app/agent_server.py
@@ -38,6 +38,7 @@ from .ingestion.job_listener import start_background_worker
 # Authentication helper and output normalization
 from .routes.agent_run import router as agent_run_router
 from .routes.baskets import router as basket_router
+from .routes.blocks import router as blocks_router
 from .routes.commits import router as commits_router
 from .routes.debug import router as debug_router
 from .routes.dump import router as dump_router
@@ -55,6 +56,7 @@ app = FastAPI(title="RightNow Agent Server")
 start_background_worker()
 app.include_router(dump_router)
 app.include_router(commits_router)
+app.include_router(blocks_router)
 # Logger for instrumentation
 logger = logging.getLogger("uvicorn.error")
 

--- a/api/src/app/routes/blocks.py
+++ b/api/src/app/routes/blocks.py
@@ -1,0 +1,24 @@
+"""
+/api/baskets/{basket_id}/blocks  –  list live blocks for a basket
+"""
+
+from fastapi import APIRouter
+
+from app.utils.supabase_client import supabase
+
+router = APIRouter(prefix="/api", tags=["blocks"])
+
+
+@router.get("/baskets/{basket_id}/blocks")
+def list_blocks(basket_id: str):
+    resp = (
+        supabase.table("context_blocks")
+        .select("id,label,type,updated_at,commit_id")
+        .eq("basket_id", basket_id)
+        .eq("is_draft", False)
+        .eq("is_superseded", False)
+        .order("updated_at", desc=True)
+        .execute()
+    )
+    return resp.data  # type: ignore[attr-defined]
+

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -4,8 +4,14 @@
  * Simple wrapper for GET requests to the backend API.
  * Uses the Next.js rewrite from /api to the configured API base.
  */
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "";
+
+function withBase(path: string) {
+  return path.startsWith("/api") && API_BASE ? `${API_BASE}${path}` : path;
+}
+
 export async function apiGet<T = any>(path: string): Promise<T> {
-  const res = await fetch(path);
+  const res = await fetch(withBase(path));
   // Handle non-OK responses
   if (!res.ok) {
     console.error(`[apiGet] Non-OK response (${res.status}) for ${path}`);
@@ -24,7 +30,7 @@ export async function apiGet<T = any>(path: string): Promise<T> {
 }
 
 export async function apiPost<T = any>(path: string, body: any): Promise<T> {
-  const res = await fetch(path, {
+  const res = await fetch(withBase(path), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),


### PR DESCRIPTION
## Summary
- add `/api/baskets/{basket_id}/blocks` route for live blocks
- mount the new router in `agent_server.py`
- support `NEXT_PUBLIC_API_BASE` in frontend API helpers

## Testing
- `ruff check api/src/app/agent_server.py api/src/app/routes/blocks.py`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a763b7b9883299ea1105b6f511221