### PR TITLE
Fix Supabase import in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      SUPABASE_URL: "https://test.supabase.co"
+      SUPABASE_SERVICE_ROLE_KEY: "test-role-key"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/api/src/utils/__init__.py
+++ b/api/src/utils/__init__.py
@@ -1,4 +1,8 @@
 from .db import json_safe
-from .supabase_client import supabase_client
+
+try:  # noqa: WPS501
+    from .supabase_client import supabase_client
+except Exception:  # pragma: no cover - best effort import
+    supabase_client = None
 
 __all__ = ["json_safe", "supabase_client"]

--- a/api/src/utils/supabase_client.py
+++ b/api/src/utils/supabase_client.py
@@ -1,7 +1,9 @@
-from os import getenv
+import os
 from supabase import create_client
 
-SUPABASE_URL = getenv("SUPABASE_URL")
-SUPABASE_SERVICE_ROLE_KEY = getenv("SUPABASE_SERVICE_ROLE_KEY")
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
 
-supabase_client = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+supabase_client = None
+if SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY:
+    supabase_client = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)


### PR DESCRIPTION
## Summary
- avoid creating Supabase client if credentials not set
- protect utils import when Supabase module can't load
- add dummy Supabase vars to CI test job

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a790ca2c8832998fd7f1c5b8e3157