### PR TITLE
Add package init for api src

### DIFF
--- a/api/src/__init__.py
+++ b/api/src/__init__.py
@@ -1,4 +1,2 @@
-"""
-Package root for API source code.
-"""
-# Ensures `/api/src` is recognized as a Python package for deployment.
+# Makes 'src' a Python package so Render's
+# start-command 'uvicorn src.app.agent_server:app' works.


### PR DESCRIPTION
## Summary
- ensure `api/src` is a package so `src.app` imports work

## Testing
- `make tests` *(fails: ModuleNotFoundError: No module named 'app.utils')*

------
https://chatgpt.com/codex/tasks/task_e_684a8d4434708329ba3ced397c56e504