### PR TITLE
Add supabase_client shim

### DIFF
--- a/api/src/app/utils/supabase_client.py
+++ b/api/src/app/utils/supabase_client.py
@@ -1,0 +1,17 @@
+"""
+Proxy shim so `import src.app.utils.supabase_client` works when Render
+starts the server with:
+    uvicorn src.app.agent_server:app
+It forwards every public name to the real supabase_client module
+located at api/src/utils/supabase_client.py
+"""
+
+# Ensure importlib sees this as the same module
+import sys
+
+from ...utils import supabase_client as _real  # noqa: F401
+
+# Re-export everything the real module provides
+from ...utils.supabase_client import *  # type: ignore  # noqa: F403,F401
+
+sys.modules[__name__] = _real


### PR DESCRIPTION
## Summary
- add module `src.app.utils.supabase_client` forwarding to the real implementation

## Testing
- `ruff check api/src/app/utils/supabase_client.py`
- `pytest -k test_json_safe.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684aa7e5aae48329a5544bb6f947804d