### PR TITLE
HOTFIX: correct job_listener import path

### DIFF
--- a/api/src/app/ingestion/job_listener.py
+++ b/api/src/app/ingestion/job_listener.py
@@ -13,7 +13,7 @@ import threading
 import time
 from typing import Any
 
-from ..utils.supabase_client import supabase_client as supabase
+from ...utils.supabase_client import supabase_client as supabase
 
 POLL_INTERVAL = float(os.getenv("INGESTION_POLL_INTERVAL", "2"))
 


### PR DESCRIPTION
## Summary
- adjust ingestion job_listener to import supabase_client from `src.utils`

## Testing
- `ruff check api/src/app/ingestion/job_listener.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684ab28bf4a48329bf083e7d9edabb89