### PR TITLE
Fix shim import path

### DIFF
--- a/api/src/app/utils/__init__.py
+++ b/api/src/app/utils/__init__.py
@@ -3,7 +3,7 @@
 import sys
 from importlib import import_module
 
-_real = import_module("api.src.utils.supabase_client")
+_real = import_module("src.utils.supabase_client")
 
 supabase_client = _real  # type: ignore
 


### PR DESCRIPTION
## Summary
- fix shim module import path so `src.app.utils` proxies to `src.utils.supabase_client`

## Testing
- `npm run test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_684ab4bb6abc8329bbb5c01e2335450b