### PR TITLE
Fix absolute import in on_input_created

### DIFF
--- a/api/src/app/events/on_input_created.py
+++ b/api/src/app/events/on_input_created.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from utils.logged_agent import logged
+from src.utils.logged_agent import logged
 
 from ..agent_tasks.layer1_infra.utils.supabase_helpers import get_supabase
 from ..agent_tasks.orch.apply_diff_blocks import apply_diffs


### PR DESCRIPTION
## Summary
- correct utils import path in on_input_created

## Testing
- `pytest -q` *(fails: Form data requires "python-multipart" to be installed)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab6e7a20c8329aef15f0f6020b2a8