### PR TITLE
Fix utils import paths

### DIFF
--- a/api/src/app/agent_tasks/layer1_infra/agents/infra_analyzer_agent.py
+++ b/api/src/app/agent_tasks/layer1_infra/agents/infra_analyzer_agent.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 import asyncpg
 from schemas.audit import AuditIn, AuditOut
 from schemas.validators import validates
-from utils.logged_agent import logged
+from src.utils.logged_agent import logged
 
 from app.event_bus import DB_URL  # reuse same URL
 from app.supabase_helpers import publish_event

--- a/api/src/app/agent_tasks/layer1_infra/agents/infra_observer_agent.py
+++ b/api/src/app/agent_tasks/layer1_infra/agents/infra_observer_agent.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 import asyncpg
 from schemas.usage import UsageIn, UsageOut
 from schemas.validators import validates
-from utils.logged_agent import logged
+from src.utils.logged_agent import logged
 
 from app.event_bus import DB_URL
 from app.supabase_helpers import publish_event

--- a/api/src/app/agent_tasks/layer1_infra/agents/infra_research_agent.py
+++ b/api/src/app/agent_tasks/layer1_infra/agents/infra_research_agent.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 import asyncpg
 from schemas.research import ResearchIn, ResearchOut
 from schemas.validators import validates
-from utils.logged_agent import logged
+from src.utils.logged_agent import logged
 
 from app.event_bus import DB_URL
 from app.supabase_helpers import publish_event

--- a/api/src/app/agent_tasks/layer2_tasks/agents/tasks_composer_agent.py
+++ b/api/src/app/agent_tasks/layer2_tasks/agents/tasks_composer_agent.py
@@ -15,7 +15,7 @@ from datetime import timezone
 
 import asyncpg
 from schemas.validators import validates
-from utils.logged_agent import logged
+from src.utils.logged_agent import logged
 
 from app.supabase_helpers import publish_event
 

--- a/api/src/app/agent_tasks/layer2_tasks/agents/tasks_editor_agent.py
+++ b/api/src/app/agent_tasks/layer2_tasks/agents/tasks_editor_agent.py
@@ -1,7 +1,7 @@
 #api/src/app/agent_tasks/layer2_tasks/agents/tasks_editor_agent.py
 
 from schemas.validators import validates
-from utils.logged_agent import logged
+from src.utils.logged_agent import logged
 
 from app.supabase_helpers import publish_event
 

--- a/api/src/app/agent_tasks/layer2_tasks/agents/tasks_validator_agent.py
+++ b/api/src/app/agent_tasks/layer2_tasks/agents/tasks_validator_agent.py
@@ -4,7 +4,7 @@ import datetime
 
 import asyncpg
 from schemas.validators import validates
-from utils.logged_agent import logged
+from src.utils.logged_agent import logged
 
 from app.event_bus import DB_URL, publish_event
 

--- a/api/src/app/agent_tasks/layer3_config/adapters/google_exporter.py
+++ b/api/src/app/agent_tasks/layer3_config/adapters/google_exporter.py
@@ -1,8 +1,8 @@
 import datetime
 
 import httpx
-from utils.db import json_safe
-from utils.logged_agent import logged
+from src.utils.db import json_safe
+from src.utils.logged_agent import logged
 
 from app.integrations.google_client import DOCS_ENDPOINT, refresh_token
 

--- a/api/src/app/agent_tasks/layer3_config/agents/config_agent.py
+++ b/api/src/app/agent_tasks/layer3_config/agents/config_agent.py
@@ -5,7 +5,7 @@ import uuid
 import asyncpg
 from schemas.config import ConfigIn, ConfigOut
 from schemas.validators import validates
-from utils.logged_agent import logged
+from src.utils.logged_agent import logged
 
 DB_URL = os.getenv("DATABASE_URL")
 

--- a/api/src/app/agent_tasks/orch/apply_diff_blocks.py
+++ b/api/src/app/agent_tasks/orch/apply_diff_blocks.py
@@ -1,6 +1,6 @@
 from schemas.block_diff import DiffBlock
 from schemas.dump_parser import ContextBlock
-from utils.db import json_safe
+from src.utils.db import json_safe
 
 from ..layer1_infra.utils.supabase_helpers import get_supabase
 

--- a/api/src/app/agent_tasks/orchestration/orch_basket_composer_agent.py
+++ b/api/src/app/agent_tasks/orchestration/orch_basket_composer_agent.py
@@ -5,7 +5,7 @@ import json
 import asyncpg
 from schemas.basket_composer import BasketComposerIn, BasketComposerOut
 from schemas.validators import validates
-from utils.logged_agent import logged
+from src.utils.logged_agent import logged
 
 from app.agent_tasks.layer2_tasks.agents.tasks_composer_agent import run as compose_run
 from app.event_bus import DB_URL, subscribe

--- a/api/src/app/agent_tasks/orchestration/orch_block_manager_agent.py
+++ b/api/src/app/agent_tasks/orchestration/orch_block_manager_agent.py
@@ -8,7 +8,7 @@ from typing import Any
 import asyncpg
 from schemas.block_manager import BlockManagerIn, BlockManagerOut
 from schemas.validators import validates
-from utils.logged_agent import logged
+from src.utils.logged_agent import logged
 
 from app.event_bus import subscribe
 

--- a/api/src/app/integrations/google_client.py
+++ b/api/src/app/integrations/google_client.py
@@ -2,7 +2,7 @@ import datetime
 import os
 
 import httpx
-from utils.db import json_safe
+from src.utils.db import json_safe
 
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
 GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")

--- a/api/src/utils/logged_agent.py
+++ b/api/src/utils/logged_agent.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from utils.event_log import log_event
+from src.utils.event_log import log_event
 
 
 def logged(agent_name: str):


### PR DESCRIPTION
## Summary
- fix utils imports to use `src.utils` package paths

## Testing
- `PYTHONPATH=api pytest -q` *(fails: attempted relative import beyond top-level package)*

------
https://chatgpt.com/codex/tasks/task_e_684ab955f5848329b690f87f95a60cd5