### PR TITLE
Add backend Makefile and testing docs

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,0 +1,2 @@
+test:
+	PYTHONPATH=src pytest -q

--- a/codex/codex_workflow_guide.md
+++ b/codex/codex_workflow_guide.md
@@ -47,6 +47,10 @@ codex
 
 ### 5. **Test Locally**
 - Run `npm run dev` or `uvicorn` as needed
+- Always use the Makefile to run backend tests:
+```bash
+make test  # sets PYTHONPATH correctly for /api tests
+```
 - Ensure frontend ↔ backend calls still succeed
 
 ### 6. **Commit and Push**


### PR DESCRIPTION
## Summary
- add Makefile under `/api` to set `PYTHONPATH` when running tests
- document the Makefile test command in `codex_workflow_guide.md`

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_684b724a19608329a64b71482d4df144