### PR TITLE
Refactor /baskets header with PageHeader component

### DIFF
--- a/web/app/baskets/page.tsx
+++ b/web/app/baskets/page.tsx
@@ -5,6 +5,14 @@ import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { EmptyState } from "@/components/ui/EmptyState";
 import BasketCard from "@/components/BasketCard";
+import PageHeader from "@/components/page/PageHeader";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
 import { getAllBaskets, BasketOverview } from "@/lib/baskets/getAllBaskets";
 
 export default function BasketsPage() {
@@ -50,37 +58,38 @@ export default function BasketsPage() {
 
   return (
     <div className="p-4 space-y-6">
-      <div className="max-w-screen-xl mx-auto px-4 flex flex-col md:flex-row justify-between items-center gap-4">
-        <div className="space-y-1">
-          <h1 className="text-2xl font-bold">🧺 My Baskets</h1>
-          <p className="text-sm text-muted-foreground">
-            Lightweight containers for your tasks, context, and thoughts
-          </p>
-        </div>
-        <div className="flex flex-col sm:flex-row flex-wrap gap-2 items-center">
-          <Button asChild>
-            <Link href="/baskets/create">+ Create Basket</Link>
-          </Button>
-          <select
-            value={sort}
-            onChange={(e) => setSort(e.target.value)}
-            className="border rounded px-2 py-1 text-sm"
-          >
-            <option value="updated">Last updated</option>
-            <option value="created">Created</option>
-            <option value="alpha">A–Z</option>
-          </select>
-          <Input
-            className="h-9 text-sm"
-            placeholder="Search"
-            value={search}
-            onChange={(e) => {
-              setSearch(e.target.value);
-              setPage(1);
-            }}
-          />
-        </div>
-      </div>
+      <PageHeader
+        emoji="🧺"
+        title="My Baskets"
+        description="Lightweight containers for your tasks, context, and thoughts"
+        actions={
+          <>
+            <Button variant="default" asChild>
+              <Link href="/baskets/create">+ Create Basket</Link>
+            </Button>
+            <Select value={sort} onValueChange={(v) => setSort(v)}>
+              <SelectTrigger className="w-[150px]">
+                <SelectValue placeholder="Last updated" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="updated">Last updated</SelectItem>
+                <SelectItem value="created">Date created</SelectItem>
+                <SelectItem value="alpha">Title</SelectItem>
+              </SelectContent>
+            </Select>
+            <Input
+              type="text"
+              placeholder="Search"
+              className="w-full sm:w-[200px]"
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(1);
+              }}
+            />
+          </>
+        }
+      />
 
       {pageData.length === 0 ? (
         <EmptyState
@@ -92,11 +101,9 @@ export default function BasketsPage() {
           }
         />
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-4 justify-center">
+        <div className="flex flex-col gap-y-4">
           {pageData.map((b) => (
-            <div key={b.id} className="max-w-[680px] w-full mx-auto">
-              <BasketCard basket={b} />
-            </div>
+            <BasketCard key={b.id} basket={b} />
           ))}
         </div>
       )}

--- a/web/components/page/PageHeader.tsx
+++ b/web/components/page/PageHeader.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+interface PageHeaderProps {
+  emoji: string
+  title: string
+  description?: string
+  actions?: React.ReactNode
+}
+
+export default function PageHeader({ emoji, title, description, actions }: PageHeaderProps) {
+  return (
+    <div className="mb-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+      <div>
+        <h1 className="text-2xl font-semibold font-brand">
+          {emoji} {title}
+        </h1>
+        {description && (
+          <p className="text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {actions && (
+        <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+          {actions}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/components/ui/select.tsx
+++ b/web/components/ui/select.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+const SelectGroup = SelectPrimitive.Group;
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-9 items-center justify-between rounded-lg border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 min-w-[8rem] overflow-hidden rounded-lg border bg-popover text-popover-foreground shadow-md animate-in fade-in-80",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.Viewport className="p-1">
+        {children}
+      </SelectPrimitive.Viewport>
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("bg-muted -mx-1 my-1 h-px", className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+};


### PR DESCRIPTION
## Summary
- add shadcn PageHeader component
- add shadcn select UI component
- refactor `/baskets` header to use PageHeader
- list baskets in a single column layout

## Testing
- `npm test`
- `make lint` *(fails: Found 171 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b7a1668e88329afd5c9d683d6425c