### PR TITLE
Fix commit route table reference

### DIFF
--- a/api/src/app/ingestion/job_listener.py
+++ b/api/src/app/ingestion/job_listener.py
@@ -13,7 +13,7 @@ import threading
 import time
 from typing import Any
 
-from ...utils.supabase_client import supabase_client as supabase
+from ..utils.supabase_client import supabase_client as supabase
 
 POLL_INTERVAL = float(os.getenv("INGESTION_POLL_INTERVAL", "2"))
 

--- a/web/app/api/baskets/[id]/commits/route.ts
+++ b/web/app/api/baskets/[id]/commits/route.ts
@@ -7,7 +7,7 @@ export async function GET(request: NextRequest, context: any) {
   const { id } = context.params;
 
   const { data, error } = await supabase
-    .from('basket_commits')
+    .from('dump_commits')
     .select('*')
     .eq('basket_id', id)
     .order('created_at', { ascending: false });


### PR DESCRIPTION
## Summary
- use `dump_commits` table in basket commit API
- fix import path in ingestion job listener

## Testing
- `make tests` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684b7cebe7cc8329812ecfae175aa266