### PR TITLE
Unify API base env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm run dev
 
 Make sure your `/web/.env.local` is set:
 ```
-NEXT_PUBLIC_API_URL=https://yarnnn.com
+NEXT_PUBLIC_API_BASE=https://yarnnn.com
 ```
 
 ### 🧪 To Run Backend (only if modifying Python code)

--- a/web/README.md
+++ b/web/README.md
@@ -65,13 +65,13 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 To configure your local development and production environments, create a `.env.local` file in the `web/` directory with the following variables:
 ```env
 # URL of your Render-hosted FastAPI backend for agent-run and task-types
-BACKEND_URL=http://localhost:10000
+NEXT_PUBLIC_API_BASE=http://localhost:10000
 # Supabase REST API URL (public)
 NEXT_PUBLIC_SUPABASE_URL=https://xyzcompany.supabase.co
 # Supabase Service Role Key (server only!)
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 ```
 On your production host (e.g., Vercel), set the same variables in the project settings:
-  • `BACKEND_URL` → your Render backend URL (e.g. `https://yarnnn.com`)
+  • `NEXT_PUBLIC_API_BASE` → your Render backend URL (e.g. `https://yarnnn.com`)
   • `NEXT_PUBLIC_SUPABASE_URL` → your Supabase project URL
   • `SUPABASE_SERVICE_ROLE_KEY` → your Supabase service role secret

--- a/web/app/api/agent-run/route.ts
+++ b/web/app/api/agent-run/route.ts
@@ -13,7 +13,7 @@ export async function POST(request: NextRequest) {
   if (cookie) headers["cookie"] = cookie;               // pass Supabase session cookie
 
   // ③ proxy to backend
-  const upstream = `${process.env.BACKEND_URL}/agent-run`;
+  const upstream = `${process.env.NEXT_PUBLIC_API_BASE}/agent-run`;
   const res = await fetch(upstream, {
     method: "POST",
     headers,

--- a/web/app/api/agent/direct/route.ts
+++ b/web/app/api/agent/direct/route.ts
@@ -13,7 +13,7 @@ export async function POST(request: NextRequest) {
   if (auth) headers["Authorization"] = auth;
   const cookie = request.headers.get("cookie");
   if (cookie) headers["cookie"] = cookie;
-  const upstream = `${process.env.BACKEND_URL}/agent/direct`;
+  const upstream = `${process.env.NEXT_PUBLIC_API_BASE}/agent/direct`;
   const res = await fetch(upstream, {
     method: "POST",
     headers,

--- a/web/app/api/agent/route.ts
+++ b/web/app/api/agent/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
   const cookie = request.headers.get("cookie");
   if (cookie) headers["cookie"] = cookie;
   // Backend URL
-  const upstream = `${process.env.BACKEND_URL}/agent`;
+  const upstream = `${process.env.NEXT_PUBLIC_API_BASE}/agent`;
   const res = await fetch(upstream, {
     method: "POST",
     headers,

--- a/web/app/api/baskets/[id]/route.ts
+++ b/web/app/api/baskets/[id]/route.ts
@@ -11,7 +11,7 @@ export async function GET(
   const cookie = req.headers.get("cookie");
   if (cookie) headers["cookie"] = cookie;
 
-  const upstream = `${process.env.BACKEND_URL}/baskets/${id}`;
+  const upstream = `${process.env.NEXT_PUBLIC_API_BASE}/baskets/${id}`;
   const res = await fetch(upstream, { headers, cache: "no-store" });
   const data = await res.json();
   return NextResponse.json(data, { status: res.status });

--- a/web/app/api/baskets/[id]/work/route.ts
+++ b/web/app/api/baskets/[id]/work/route.ts
@@ -9,7 +9,7 @@ export async function POST(req: NextRequest, context: any) {
   const cookie = req.headers.get("cookie");
   if (cookie) headers["cookie"] = cookie;
 
-  const upstream = `${process.env.BACKEND_URL}/baskets/${id}/work`;
+  const upstream = `${process.env.NEXT_PUBLIC_API_BASE}/baskets/${id}/work`;
   const res = await fetch(upstream, {
     method: "POST",
     headers,

--- a/web/app/api/baskets/route.ts
+++ b/web/app/api/baskets/route.ts
@@ -8,7 +8,7 @@ export async function POST(request: NextRequest) {
   const cookie = request.headers.get("cookie");
   if (cookie) headers["cookie"] = cookie;
 
-  const upstream = `${process.env.BACKEND_URL}/baskets`;
+  const upstream = `${process.env.NEXT_PUBLIC_API_BASE}/baskets`;
   const res = await fetch(upstream, {
     method: "POST",
     headers,

--- a/web/app/api/manager-chat/route.ts
+++ b/web/app/api/manager-chat/route.ts
@@ -18,7 +18,7 @@ export async function POST(req: NextRequest) {
 
   const updated = { ...data.inputs, [field]: value };
 
-  await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/agent`, {
+  await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/agent`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({

--- a/web/app/api/task-types/route.ts
+++ b/web/app/api/task-types/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(request: NextRequest) {
-  // Determine API base URL, falling back to public env var if needed
-  const baseUrl = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_API_URL;
+  // Determine API base URL from env
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE;
   if (!baseUrl) {
     return NextResponse.json(
-      { error: 'Missing BACKEND_URL or NEXT_PUBLIC_API_URL environment variable' },
+      { error: 'Missing NEXT_PUBLIC_API_BASE environment variable' },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Summary
- standardize environment variable to `NEXT_PUBLIC_API_BASE`
- update README instructions accordingly
- update API route handlers to read from `NEXT_PUBLIC_API_BASE`

## Testing
- `make lint` *(fails: Import block is un-sorted or un-formatted)*
- `make tests` *(fails: ImportError during test collection)*
- `node` script to verify routing logic

------
https://chatgpt.com/codex/tasks/task_e_684b7cff48688329966c904996127c4d