### PR TITLE
Fix agent-run error handling

### DIFF
--- a/api/src/app/routes/agent_run.py
+++ b/api/src/app/routes/agent_run.py
@@ -1,5 +1,6 @@
 import logging
-from fastapi import APIRouter, Body
+from fastapi import APIRouter, Body, Request
+from fastapi.responses import JSONResponse
 from ..events.on_input_created import handle_event
 
 logger = logging.getLogger("uvicorn.error")
@@ -7,8 +8,16 @@ logger = logging.getLogger("uvicorn.error")
 router = APIRouter(tags=["agents"])
 
 @router.post("/agent-run")
-async def agent_run(payload: dict = Body(...)):
+async def agent_run(request: Request):
     """Forward incoming events directly to the handler."""
+    try:
+        payload = await request.json()
+    except Exception:
+        return JSONResponse(
+            {"error": "Missing or invalid JSON in request body"},
+            status_code=400,
+        )
+
     # Accept both {event: {...}} and direct {...} formats
     event = payload["event"] if isinstance(payload.get("event"), dict) else payload
     logger.info("/agent-run payload type: %s", type(event).__name__)

--- a/web/app/api/agent-run/route.ts
+++ b/web/app/api/agent-run/route.ts
@@ -1,6 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest) {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE;
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: "Missing NEXT_PUBLIC_API_BASE environment variable" },
+      { status: 500 }
+    );
+  }
+
   // ① copy incoming body
   const body = await request.text();
 
@@ -8,12 +16,12 @@ export async function POST(request: NextRequest) {
   //    FastAPI validates either one, and RSC/Route Handlers strip auth headers automatically.
   const headers: HeadersInit = { "Content-Type": "application/json" };
   const auth = request.headers.get("authorization");
-  if (auth) headers["Authorization"] = auth;          // capital-A
+  if (auth) headers["Authorization"] = auth; // capital-A
   const cookie = request.headers.get("cookie");
-  if (cookie) headers["cookie"] = cookie;               // pass Supabase session cookie
+  if (cookie) headers["cookie"] = cookie; // pass Supabase session cookie
 
   // ③ proxy to backend
-  const upstream = `${process.env.NEXT_PUBLIC_API_BASE}/agent-run`;
+  const upstream = `${baseUrl}/agent-run`;
   const res = await fetch(upstream, {
     method: "POST",
     headers,

--- a/web/lib/baskets/createBasketWithInput.ts
+++ b/web/lib/baskets/createBasketWithInput.ts
@@ -8,6 +8,10 @@ export interface BasketInputPayload {
 }
 
 export async function createBasketWithInput({ text, files = [] }: BasketInputPayload) {
+  if (!text.trim() && files.length === 0) {
+    throw new Error("createBasketWithInput called with empty input.");
+  }
+
   const supabase = createClient();
 
   const { data: userData } = await supabase.auth.getUser();


### PR DESCRIPTION
## Summary
- validate `NEXT_PUBLIC_API_BASE` in agent-run proxy
- handle empty or invalid JSON in FastAPI agent_run route
- guard against empty payloads in `createBasketWithInput`

## Testing
- `make format` *(fails: UP035 `typing.Dict` is deprecated)*
- `make lint` *(fails: import block is un-sorted or un-formatted)*
- `make tests` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_684b822565e48329b80fc297fb887331