### PR TITLE
Add recent progress summarizer

### DIFF
--- a/web/app/api/summarize-session/route.ts
+++ b/web/app/api/summarize-session/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@/lib/supabase/server";
+import dayjs from "dayjs";
+
+export async function POST(req: NextRequest) {
+    const body = await req.json();
+    const { basket_id } = body;
+    const supabase = createServerClient();
+
+    const since = dayjs().subtract(48, "hour").toISOString();
+    const { data: commits } = await supabase
+        .from("dump_commits")
+        .select("id, summary, created_at")
+        .eq("basket_id", basket_id)
+        .gte("created_at", since)
+        .order("created_at", { ascending: true });
+
+    if (!commits || commits.length === 0) {
+        return NextResponse.json({
+            summary: "No recent updates in the last 48 hours.",
+        });
+    }
+
+    const formatted = commits
+        .map(
+            (c) =>
+                `• ${dayjs(c.created_at).format("MMM D")}: ${c.summary || "Unnamed commit"}`,
+        )
+        .join("\n");
+    const summary = `Here’s what you’ve worked on recently:\n${formatted}`;
+    return NextResponse.json({ summary });
+}

--- a/web/components/work/BlocksWorkspace.tsx
+++ b/web/components/work/BlocksWorkspace.tsx
@@ -1,28 +1,55 @@
 "use client";
+import { useState } from "react";
 import BlocksList from "./BlocksList";
 import { usePendingChanges } from "@/lib/baskets/usePendingChanges";
 
 interface Props {
-  basketId: string;
-  highlightCommitId?: string | null;
+    basketId: string;
+    highlightCommitId?: string | null;
 }
 
-export default function BlocksWorkspace({ basketId, highlightCommitId }: Props) {
-  const pending = usePendingChanges(basketId);
+export default function BlocksWorkspace({
+    basketId,
+    highlightCommitId,
+}: Props) {
+    const pending = usePendingChanges(basketId);
+    const [summary, setSummary] = useState<string | null>(null);
 
-  return (
-    <section className="flex-1 flex flex-col overflow-hidden">
-      <header className="h-10 px-6 flex items-center border-b">
-        {pending > 0 && (
-          <button
-            onClick={() => alert("Change queue coming soon")}
-            className="ml-auto text-xs bg-yellow-100 text-yellow-800 px-2 py-1 rounded-md"
-          >
-            ⚠︎ {pending} change{pending > 1 ? "s" : ""}
-          </button>
-        )}
-      </header>
-      <BlocksList basketId={basketId} highlightCommitId={highlightCommitId} />
-    </section>
-  );
+    const handleSummarizeSession = async () => {
+        const res = await fetch("/api/summarize-session", {
+            method: "POST",
+            body: JSON.stringify({ basket_id: basketId }),
+        });
+        const { summary } = await res.json();
+        setSummary(summary);
+    };
+
+    return (
+        <section className="flex-1 flex flex-col overflow-hidden">
+            <header className="h-10 px-6 flex items-center border-b gap-2 justify-between">
+                {pending > 0 && (
+                    <button className="text-xs bg-yellow-100 text-yellow-800 px-2 py-1 rounded-md">
+                        ⚠︎ {pending} change{pending > 1 ? "s" : ""}
+                    </button>
+                )}
+                <button
+                    onClick={handleSummarizeSession}
+                    className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded-md"
+                >
+                    🪄 Summarize Recent Progress
+                </button>
+            </header>
+
+            {summary && (
+                <div className="bg-muted p-4 text-sm border-b font-mono text-muted-foreground">
+                    <strong>Summary:</strong> {summary}
+                </div>
+            )}
+
+            <BlocksList
+                basketId={basketId}
+                highlightCommitId={highlightCommitId}
+            />
+        </section>
+    );
 }


### PR DESCRIPTION
## Summary
- show a _Summarize Recent Progress_ button in the basket workspace
- return a placeholder summary of the last 48h of commits from `/api/summarize-session`

## Testing
- `npm test`
- `make tests` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684b817a73188329bb60aaa3b8043b47