### PR TITLE
Implement blocks and change-queue API routes

### DIFF
--- a/web/app/api/baskets/[id]/blocks/route.ts
+++ b/web/app/api/baskets/[id]/blocks/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest, context: any) {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE;
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: 'Missing NEXT_PUBLIC_API_BASE environment variable' },
+      { status: 500 },
+    );
+  }
+
+  const { id } = context.params;
+  let upstream: string;
+  try {
+    upstream = new URL(`/baskets/${id}/blocks${req.nextUrl.search}` , baseUrl).toString();
+  } catch {
+    return NextResponse.json({ error: 'Invalid API base URL' }, { status: 500 });
+  }
+
+  const headers: HeadersInit = {};
+  const auth = req.headers.get('authorization');
+  if (auth) headers['Authorization'] = auth;
+  const cookie = req.headers.get('cookie');
+  if (cookie) headers['cookie'] = cookie;
+
+  let res: Response;
+  try {
+    res = await fetch(upstream, { headers, cache: 'no-store' });
+  } catch {
+    return NextResponse.json(
+      { error: 'Failed to connect to upstream API' },
+      { status: 502 },
+    );
+  }
+
+  if (!res.ok) {
+    return NextResponse.json({ error: 'Upstream API error' }, { status: 502 });
+  }
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/web/app/api/baskets/[id]/change-queue/route.ts
+++ b/web/app/api/baskets/[id]/change-queue/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest, context: any) {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE;
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: 'Missing NEXT_PUBLIC_API_BASE environment variable' },
+      { status: 500 },
+    );
+  }
+
+  const { id } = context.params;
+  let upstream: string;
+  try {
+    upstream = new URL(`/baskets/${id}/change-queue${req.nextUrl.search}`, baseUrl).toString();
+  } catch {
+    return NextResponse.json({ error: 'Invalid API base URL' }, { status: 500 });
+  }
+
+  const headers: HeadersInit = {};
+  const auth = req.headers.get('authorization');
+  if (auth) headers['Authorization'] = auth;
+  const cookie = req.headers.get('cookie');
+  if (cookie) headers['cookie'] = cookie;
+
+  let res: Response;
+  try {
+    res = await fetch(upstream, { headers, cache: 'no-store' });
+  } catch {
+    return NextResponse.json(
+      { error: 'Failed to connect to upstream API' },
+      { status: 502 },
+    );
+  }
+
+  if (!res.ok) {
+    return NextResponse.json({ error: 'Upstream API error' }, { status: 502 });
+  }
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/web/components/timeline/CommitTimeline.tsx
+++ b/web/components/timeline/CommitTimeline.tsx
@@ -10,10 +10,17 @@ interface Props {
 }
 
 export default function CommitTimeline({ basketId, onSelect }: Props) {
-  const { commits, isLoading } = useCommits(basketId);
+  const { commits, isLoading, error } = useCommits(basketId);
 
   if (isLoading) {
     return <aside className="p-4 w-52 text-sm text-muted-foreground">Loading…</aside>;
+  }
+  if (error) {
+    return (
+      <aside className="p-4 w-52 text-sm text-red-600">
+        Failed to load commits
+      </aside>
+    );
   }
   return (
     <aside className="p-4 w-60 border-r bg-background/50 overflow-y-auto">

--- a/web/components/work/BlocksList.tsx
+++ b/web/components/work/BlocksList.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 export default function BlocksList({ basketId, highlightCommitId }: Props) {
-  const { blocks, isLoading } = useBlocks(basketId);
+  const { blocks, isLoading, error } = useBlocks(basketId);
 
   if (isLoading) {
     return (
@@ -19,6 +19,12 @@ export default function BlocksList({ basketId, highlightCommitId }: Props) {
           <li key={idx} className="border rounded-md p-3 h-8" />
         ))}
       </ul>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6 text-sm text-red-600">Failed to load blocks</div>
     );
   }
 


### PR DESCRIPTION
## Summary
- add `/blocks` proxy route
- add `/change-queue` proxy route
- handle API errors in commits list
- handle API errors in blocks list

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b8fe553708329809b24c2a088ac75