### PR TITLE
Add route registry drift checker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,17 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install deps for route check
+        working-directory: web
+        run: npm ci
+      - name: Run route drift check
+        run: |
+          npx ts-node web/scripts/generate-route-registry.ts
+          npx ts-node web/scripts/check-route-drift.ts
       - name: Run contract & unit tests
         run: |
           pushd api

--- a/web/generated-route-registry.json
+++ b/web/generated-route-registry.json
@@ -1,0 +1,15 @@
+[
+  "/api/agent",
+  "/api/agent-run",
+  "/api/agent/direct",
+  "/api/baskets",
+  "/api/baskets/[id]",
+  "/api/baskets/[id]/blocks",
+  "/api/baskets/[id]/change-queue",
+  "/api/baskets/[id]/commits",
+  "/api/baskets/[id]/work",
+  "/api/manager-chat",
+  "/api/summarize-session",
+  "/api/system-check",
+  "/api/task-types"
+]

--- a/web/route-contracts.json
+++ b/web/route-contracts.json
@@ -1,0 +1,13 @@
+[
+  "/api/agent",
+  "/api/agent-run",
+  "/api/manager-chat",
+  "/api/baskets",
+  "/api/baskets/[id]",
+  "/api/baskets/[id]/blocks",
+  "/api/baskets/[id]/change-queue",
+  "/api/baskets/[id]/commits",
+  "/api/summarize-session",
+  "/api/task-types"
+]
+

--- a/web/scripts/check-route-drift.ts
+++ b/web/scripts/check-route-drift.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+
+const expectedPath = path.join(__dirname, '..', 'route-contracts.json');
+const actualPath = path.join(__dirname, '..', 'generated-route-registry.json');
+
+const expected: string[] = JSON.parse(fs.readFileSync(expectedPath, 'utf-8'));
+const actual: string[] = JSON.parse(fs.readFileSync(actualPath, 'utf-8'));
+
+const missing = expected.filter((route) => !actual.includes(route));
+const extra = actual.filter((route) => !expected.includes(route));
+
+if (missing.length || extra.length) {
+  console.error('❌ Route registry drift detected!');
+  if (missing.length) {
+    console.error('\nMissing in generated routes:');
+    missing.forEach((r) => console.error(`  - ${r}`));
+  }
+  if (extra.length) {
+    console.error('\nUnexpected extra routes:');
+    extra.forEach((r) => console.error(`  - ${r}`));
+  }
+  process.exit(1);
+} else {
+  console.log('✅ Route registry matches expected routes.');
+}

--- a/web/scripts/generate-route-registry.ts
+++ b/web/scripts/generate-route-registry.ts
@@ -1,0 +1,28 @@
+import fs from 'fs';
+import path from 'path';
+
+const apiDir = path.join(__dirname, '..', 'app', 'api');
+const outputFile = path.join(__dirname, '..', 'generated-route-registry.json');
+
+function scanRoutes(dir: string, baseRoute = '/api'): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  let routes: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    const routePath = path.join(baseRoute, entry.name).replace(/\\/g, '/');
+
+    if (entry.isDirectory()) {
+      routes = routes.concat(scanRoutes(fullPath, routePath));
+    } else if (entry.isFile() && entry.name === 'route.ts') {
+      const cleanRoute = baseRoute.replace(/\\/g, '/');
+      routes.push(cleanRoute);
+    }
+  }
+
+  return routes;
+}
+
+const routes = scanRoutes(apiDir).sort();
+fs.writeFileSync(outputFile, JSON.stringify(routes, null, 2) + '\n');
+console.log(`✅ Route registry written to ${outputFile}`);


### PR DESCRIPTION
## Summary
- add script to detect route mismatches between `route-contracts.json` and the generated registry
- run the drift check in CI before Python tests

## Testing
- `npx ts-node --compiler-options '{"module":"commonjs"}' web/scripts/generate-route-registry.ts`
- `npx ts-node --compiler-options '{"module":"commonjs"}' web/scripts/check-route-drift.ts` *(fails with extra routes)*
- `PYTHONPATH=api pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b931050d4832988c6189e4b33a297