### PR TITLE
Add route drift check in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,21 +18,21 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - name: Install Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-      - name: Install deps for route check
-        working-directory: web
-        run: npm ci
-      - name: Run route drift check
-        run: |
-          npx ts-node web/scripts/generate-route-registry.ts
-          npx ts-node web/scripts/check-route-drift.ts
       - name: Run contract & unit tests
         run: |
           pushd api
           pip install -r requirements.txt
           popd
           pytest -q
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install web dependencies
+        working-directory: web
+        run: npm install
+      - name: Run route drift check
+        run: |
+          npx ts-node --compiler-options '{"module":"commonjs"}' web/scripts/generate-route-registry.ts
+          npx ts-node --compiler-options '{"module":"commonjs"}' web/scripts/check-route-drift.ts
 

--- a/web/route-contracts.json
+++ b/web/route-contracts.json
@@ -1,13 +1,15 @@
 [
   "/api/agent",
   "/api/agent-run",
-  "/api/manager-chat",
+  "/api/agent/direct",
   "/api/baskets",
   "/api/baskets/[id]",
   "/api/baskets/[id]/blocks",
   "/api/baskets/[id]/change-queue",
   "/api/baskets/[id]/commits",
+  "/api/baskets/[id]/work",
+  "/api/manager-chat",
   "/api/summarize-session",
+  "/api/system-check",
   "/api/task-types"
 ]
-


### PR DESCRIPTION
## Summary
- run Python tests first in CI, then install Node
- install web dependencies
- run scripts to generate route registry and check for drift
- update route contract with the latest routes

## Testing
- `PYTHONPATH=api pytest -q`
- `npx -y ts-node --compiler-options '{"module":"commonjs"}' web/scripts/generate-route-registry.ts && npx -y ts-node --compiler-options '{"module":"commonjs"}' web/scripts/check-route-drift.ts`
- `npm install` *(fails: unable to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_684ba336f9f483299555e75ca02f4c75