### PR TITLE
Fix proxy routes to include API base path

### DIFF
--- a/web/app/api/baskets/[id]/blocks/route.ts
+++ b/web/app/api/baskets/[id]/blocks/route.ts
@@ -12,7 +12,7 @@ export async function GET(req: NextRequest, context: any) {
   const { id } = context.params;
   let upstream: string;
   try {
-    upstream = new URL(`/baskets/${id}/blocks${req.nextUrl.search}` , baseUrl).toString();
+    upstream = new URL(`/api/baskets/${id}/blocks${req.nextUrl.search}`, baseUrl).toString();
   } catch {
     return NextResponse.json({ error: 'Invalid API base URL' }, { status: 500 });
   }

--- a/web/app/api/baskets/[id]/change-queue/route.ts
+++ b/web/app/api/baskets/[id]/change-queue/route.ts
@@ -12,7 +12,7 @@ export async function GET(req: NextRequest, context: any) {
   const { id } = context.params;
   let upstream: string;
   try {
-    upstream = new URL(`/baskets/${id}/change-queue${req.nextUrl.search}`, baseUrl).toString();
+    upstream = new URL(`/api/baskets/${id}/change-queue${req.nextUrl.search}`, baseUrl).toString();
   } catch {
     return NextResponse.json({ error: 'Invalid API base URL' }, { status: 500 });
   }


### PR DESCRIPTION
## Summary
- correct upstream URLs for basket API proxy routes

## Testing
- `npm run lint` *(fails: Next.js plugin not detected and parsing errors)*
- `make lint` *(fails: ruff found 88 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ba960c274832986604546c73c3024