### PR TITLE
Update docs for backend URL env

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ uvicorn app.agent_server:app --reload
 ```
 
 Set `NEXT_PUBLIC_API_BASE` in `web/.env.local` to point to your backend instance.
+After updating the variable, redeploy the Next.js frontend so runtime route handlers
+pick up the new value. You can verify the configuration by requesting
+`/api/baskets/<id>/change-queue`; the backend logs should show a GET request and
+a non-500 response.
 
 The `/agent` endpoint handles agent requests and is stable across deployments.
 

--- a/web/.env.sample
+++ b/web/.env.sample
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_API_BASE=http://localhost:10000
+NEXT_PUBLIC_SUPABASE_URL=https://yourproject.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!/.env.sample
 
 # vercel
 .vercel

--- a/web/README.md
+++ b/web/README.md
@@ -75,3 +75,6 @@ On your production host (e.g., Vercel), set the same variables in the project se
   • `NEXT_PUBLIC_API_BASE` → your Render backend URL (e.g. `https://yarnnn.com`)
   • `NEXT_PUBLIC_SUPABASE_URL` → your Supabase project URL
   • `SUPABASE_SERVICE_ROLE_KEY` → your Supabase service role secret
+After updating `NEXT_PUBLIC_API_BASE`, redeploy the frontend so route handlers
+use the new value. You can confirm by requesting `/api/baskets/<id>/change-queue`
+and checking that the backend logs show a GET request without a 500 error.


### PR DESCRIPTION
## Summary
- clarify redeploy instructions for `NEXT_PUBLIC_API_BASE`
- allow committing env samples and add one under `web`

## Testing
- `npm test`
- `make tests` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684bac3324c08329a03f8f1dca30a8d0