### PR TITLE
Rewrite landing and about pages

### DIFF
--- a/web/app/about/page.tsx
+++ b/web/app/about/page.tsx
@@ -1,40 +1,48 @@
+/* updated about page */
+
 import LandingHeader from "@/components/landing/LandingHeader";
 import LandingFooter from "@/components/landing/LandingFooter";
 import SystemCapabilitiesSection from "@/components/landing/SystemCapabilitiesSection";
 import SystemPillarsSection from "@/components/landing/SystemPillarsSection";
-import Brand from "@/components/Brand";
 
-export default function HomePage() {
-    return (
-        <>
-            <LandingHeader />
-            <main>
-                <section className="w-full max-w-[1200px] mx-auto px-4 py-[120px] space-y-6">
-                    <h1 className="text-foreground text-4xl md:text-6xl font-bold tracking-tight leading-tight text-left">
-                        <div className="font-brand text-3xl md:text-7xl">yarnnn</div>
-                        <br />
-                        is your memory operating system
-                        <br />
-                        for async thinkers and creative builders
-                    </h1>
-                    <p className="text-lg leading-relaxed max-w-2xl">
-                        Instead of juggling scattered docs, forgotten chats, and one-off prompts —
-                        yarnnn lets you work with AI in a way that <em>remembers</em>.
-                        Every thought you drop becomes a reusable building block, woven into your bigger goal.
-                    </p>
-                    <p className="text-lg leading-relaxed max-w-2xl">
-                        We call these threads 'baskets' — a container for your intent, context, and evolution.
-                        Inside, yarnnn helps you organize, reflect, and act — with context-aware agents always ready to assist.
-                    </p>
-                </section>
-                <SystemPillarsSection />
-                <SystemCapabilitiesSection />
-                <footer className="px-4 py-12 text-center text-sm text-muted-foreground">
-                    Our mission is to help async thinkers and independent creators
-                    work with clarity and continuity — powered by thoughtful memory design.
-                </footer>
-            </main>
-            <LandingFooter />
-        </>
-    );
+export default function AboutPage() {
+  return (
+    <>
+      <LandingHeader />
+      <main>
+        <section className="w-full max-w-[1200px] mx-auto px-4 py-[120px] space-y-6">
+          <h1 className="text-foreground text-4xl md:text-6xl font-bold tracking-tight leading-tight text-left">
+            <div className="font-brand text-3xl md:text-7xl">yarnnn</div>
+            <br />
+            is your memory operating system<br />
+            for async thinkers and evolving strategy
+          </h1>
+
+          <p className="text-lg leading-relaxed max-w-2xl">
+            Most tools make you start from scratch every time you open a doc or prompt an AI.
+            Yarnnn gives you a living memory — a space where your thoughts, chats, and notes grow into strategy over time.
+          </p>
+
+          <p className="text-lg leading-relaxed max-w-2xl">
+            It works through <strong>baskets</strong> — threads of ongoing intent.
+            Inside each basket, yarnnn helps you reflect, organize, and act using
+            <strong> context blocks</strong> and <strong>briefs</strong> — with agents that keep up as you go.
+          </p>
+
+          <p className="text-lg leading-relaxed max-w-2xl">
+            Whether you're juggling startup chaos, building a creative business, or managing multiple brands —
+            yarnnn helps you remember what matters and move forward with clarity.
+          </p>
+        </section>
+
+        <SystemPillarsSection />
+        <SystemCapabilitiesSection />
+
+        <footer className="px-4 py-12 text-center text-sm text-muted-foreground">
+          Our mission is to help independent creators and async teams think clearly, remember continuously, and act with evolving context.
+        </footer>
+      </main>
+      <LandingFooter />
+    </>
+  );
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,7 +1,8 @@
+/* updated landing page */
+
 "use client";
 
 import Link from 'next/link';
-import { ArrowsOutCardinal, Butterfly, MicrophoneStage } from 'phosphor-react';
 import LandingHeader from '@/components/landing/LandingHeader';
 import LandingFooter from '@/components/landing/LandingFooter';
 import BackgroundPaths from '@/components/BackgroundPaths';
@@ -9,58 +10,79 @@ import BackgroundPaths from '@/components/BackgroundPaths';
 export default function LandingPage() {
   return (
     <>
-      {/* Animated BG behind just the header and hero */}
       <section className="relative overflow-hidden min-h-[500px]">
         <BackgroundPaths />
-          <div className="relative z-10">
-            <LandingHeader />
-            <div className="max-w-[1200px] mx-auto px-4 py-24 flex flex-col items-start">
-              <br />
-              <div className="font-brand text-3xl md:text-7xl">yarnnn</div>
-              <br />
-              <br />
-              <h1 className="text-3xl md:text-5xl font-bold mb-4">
-                memory operating system<br />
-                <br />                
-                to weave your thoughts<br />
-              </h1>
-              <br />
-              <p className="text-lg leading-relaxed mb-6 max-w-xl">
-                designed for working with AI
-                start ideas with a simple dump.
-                yarnnn turns it into a structured,
-                living memory powered by "context blocks" and "task baskets".
-              </p>
-              <Link
-                href="/baskets/create"
-                className="inline-block px-8 py-4 border border-foreground text-foreground rounded-md hover:bg-black hover:text-white transition"
-              >
-                drop your first thought
-              </Link>
-            </div>
+        <div className="relative z-10">
+          <LandingHeader />
+          <div className="max-w-[1200px] mx-auto px-4 py-24 flex flex-col items-start">
+            <br />
+            <div className="font-brand text-3xl md:text-7xl">yarnnn</div>
+            <br />
+            <br />
+            <h1 className="text-3xl md:text-5xl font-bold mb-4">
+              dump as you go,<br />
+              and we keep up.
+            </h1>
+            <br />
+            <p className="text-lg leading-relaxed mb-6 max-w-xl">
+              yarnnn is your live memory layer for creative and strategic work.
+              drop voice notes, AI chats, screenshots, or ideas — and we’ll weave it all into reusable context blocks and evolving briefs.
+            </p>
+            <Link
+              href="/baskets/create"
+              className="inline-block px-8 py-4 border border-foreground text-foreground rounded-md hover:bg-black hover:text-white transition"
+            >
+              drop your first thought
+            </Link>
+          </div>
         </div>
       </section>
 
-      {/* Main content - no animated background */}
       <main className="bg-background text-foreground flex flex-col">
         <div className="max-w-[1200px] mx-auto px-4 w-full">
-          {/* Description + Feature Icons */}
+          {/* Benefits */}
           <section id="benefits" className="px-6 py-12 border-b grid grid-cols-1 md:grid-cols-2 gap-10">
             <p className="text-lg leading-relaxed">
-              yarnnn helps you organize evolving projects, reuse your thinking, and get context-aware assistance.
+              yarnnn helps indie thinkers, creative builders, and async teams keep continuity
+              across everything they say, plan, and try to remember. one space to store memory, grow ideas, and synthesize strategy.
             </p>
             <div className="space-y-10">
               <div className="flex items-center gap-4">
                 <span className="text-xl">🧺</span>
-                <span className="text-sm">One basket = one focused context thread</span>
+                <span className="text-sm">Baskets collect your thought stream — async, messy, real-time</span>
               </div>
               <div className="flex items-center gap-4">
                 <span className="text-xl">◾</span>
-                <span className="text-sm">Blocks store brand tone, strategy, goals</span>
+                <span className="text-sm">Blocks store reusable brand tone, goals, and strategy</span>
               </div>
               <div className="flex items-center gap-4">
-                <span className="text-xl">🪄</span>
-                <span className="text-sm">Get help that understands your memory</span>
+                <span className="text-xl">🧠</span>
+                <span className="text-sm">Briefs synthesize your context into plans that feel like you</span>
+              </div>
+            </div>
+          </section>
+
+          {/* New: Use Cases Section */}
+          <section id="use-cases" className="px-6 py-12 border-b space-y-8">
+            <h2 className="text-2xl font-bold">who yarnnn is for</h2>
+            <div className="space-y-6">
+              <div>
+                <p className="text-md font-semibold">⚒️ Indie Hackers & Startup Builders</p>
+                <p className="text-sm text-muted-foreground">
+                  turn raw product thoughts and pitch scraps into a roadmap — without losing context.
+                </p>
+              </div>
+              <div>
+                <p className="text-md font-semibold">✍️ Creative Solopreneurs</p>
+                <p className="text-sm text-muted-foreground">
+                  turn voice notes, AI chat threads, and scattered feedback into living briefs that evolve with your work.
+                </p>
+              </div>
+              <div>
+                <p className="text-md font-semibold">📈 Freelance Strategists & Marketers</p>
+                <p className="text-sm text-muted-foreground">
+                  keep every client’s tone, positioning, and deliverables in one evolving memory space.
+                </p>
               </div>
             </div>
           </section>
@@ -71,15 +93,14 @@ export default function LandingPage() {
               href="/about"
               className="text-md underline underline-offset-2 hover:text-black/70 transition"
             >
-              About &rarr;
+              Learn how it works &rarr;
             </Link>
           </section>
 
-          {/* Mission Statement */}
+          {/* Mission */}
           <section className="px-6 py-12 border-t border-b">
             <p className="text-xl md:text-2xl max-w-3xl mx-auto text-center">
-              🧶 work with clarity 
-              one thought at a time
+              🧶 from chaotic thoughts to evolving clarity — one drop at a time
             </p>
           </section>
         </div>


### PR DESCRIPTION
## Summary
- rewrite landing page tagline and descriptions
- outline use cases and updated pitch
- refresh about page with new philosophy and async framing

## Testing
- `npm test`
- `make -C api test` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_684bb0a41a2c832990628d1128964ea7