### PR TITLE
Prefix backend API routes with /api

### DIFF
--- a/api/src/app/agent_server.py
+++ b/api/src/app/agent_server.py
@@ -35,7 +35,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .ingestion.job_listener import start_background_worker
 
-# Authentication helper and output normalization
+# Route modules
 from .routes.agent_run import router as agent_run_router
 from .routes.baskets import router as basket_router
 from .routes.blocks import router as blocks_router
@@ -48,6 +48,9 @@ from .routes.task_brief import router as task_brief_router
 # Task routing for execution
 from .routes.task_types import router as task_types_router
 
+# Agent handlers
+from .agent_entrypoints import router as agent_router, run_agent, run_agent_direct
+
 # ── Environment variable for Bubble webhook URL
 CHAT_URL = os.getenv("BUBBLE_CHAT_URL")
 
@@ -55,42 +58,49 @@ CHAT_URL = os.getenv("BUBBLE_CHAT_URL")
 # ── FastAPI app ────────────────────────────────────────────────────────────
 app = FastAPI(title="RightNow Agent Server")
 start_background_worker()
-app.include_router(dump_router)
-app.include_router(commits_router)
-app.include_router(blocks_router)
-app.include_router(change_queue_router)
+
+# ── Unified API mounting ────────────────────────────────────────────────
+api = FastAPI()
+
+# Route group under /api
+api.include_router(agent_run_router, prefix="/api")
+api.include_router(dump_router, prefix="/api")
+api.include_router(commits_router, prefix="/api")
+api.include_router(blocks_router, prefix="/api")
+api.include_router(change_queue_router, prefix="/api")
+api.include_router(task_types_router, prefix="/api")
+api.include_router(task_brief_router, prefix="/api")
+api.include_router(basket_router, prefix="/api")
+api.include_router(debug_router, prefix="/api")
+api.include_router(agent_router, prefix="/api")
+
+# Agent entrypoints with API prefix
+
+@api.post("/api/agent")
+async def api_run_agent(request):
+    return await run_agent(request)
+
+@api.post("/api/agent/direct")
+async def api_run_agent_direct(request):
+    return await run_agent_direct(request)
+
+# Mount the grouped API to root
+app.mount("", api)
+
 # Logger for instrumentation
 logger = logging.getLogger("uvicorn.error")
 
 
 @app.get("/", include_in_schema=False)
 async def root():  # pragma: no cover
-    """Health-check endpoint."""
     return {"status": "ok"}
 
 
 # Allow CORS from any origin (adjust in production)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # replace "*" with your front-end URL(s)
+    allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-# Mount agent entrypoint handlers
-from .agent_entrypoints import router as agent_router, run_agent, run_agent_direct  # noqa: E402
-
-app.post("/agent")(run_agent)
-app.post("/agent/direct")(run_agent_direct)
-app.include_router(agent_router)
-
-# Mount task-types routes
-app.include_router(task_types_router)
-# Mount task-brief routes
-app.include_router(task_brief_router)
-# Mount basket routes
-app.include_router(basket_router)
-# Agent-run proxy route
-app.include_router(agent_run_router)
-app.include_router(debug_router)

--- a/api/src/app/routes/blocks.py
+++ b/api/src/app/routes/blocks.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, HTTPException
 
 from ..utils.supabase_client import supabase_client as supabase
 
-router = APIRouter(prefix="/api", tags=["blocks"])
+router = APIRouter(tags=["blocks"])
 
 logger = logging.getLogger("uvicorn.error")
 

--- a/api/src/app/routes/change_queue.py
+++ b/api/src/app/routes/change_queue.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, HTTPException
 
 from ..utils.supabase_client import supabase_client as supabase
 
-router = APIRouter(prefix="/api", tags=["change-queue"])
+router = APIRouter(tags=["change-queue"])
 
 logger = logging.getLogger("uvicorn.error")
 

--- a/api/src/app/routes/commits.py
+++ b/api/src/app/routes/commits.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException, Query
 
 from ..utils.supabase_client import supabase_client as supabase
 
-router = APIRouter(prefix="/api", tags=["commits"])
+router = APIRouter(tags=["commits"])
 
 logger = logging.getLogger("uvicorn.error")
 

--- a/api/src/app/routes/dump.py
+++ b/api/src/app/routes/dump.py
@@ -14,7 +14,7 @@ from ..utils.supabase_client import supabase_client as supabase
 
 logger = logging.getLogger("uvicorn.error")
 
-router = APIRouter(prefix="/api", tags=["dump"])
+router = APIRouter(tags=["dump"])
 
 _ALLOWED_MIME = {"text/plain", "text/markdown"}
 

--- a/api/tests/api/test_change_queue_endpoint.py
+++ b/api/tests/api/test_change_queue_endpoint.py
@@ -12,7 +12,7 @@ os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "d.e.f")
 from app.routes.change_queue import router as queue_router
 
 app = FastAPI()
-app.include_router(queue_router)
+app.include_router(queue_router, prefix="/api")
 client = TestClient(app)
 
 

--- a/api/tests/api/test_commit_insertion.py
+++ b/api/tests/api/test_commit_insertion.py
@@ -12,7 +12,7 @@ os.environ.setdefault("SUPABASE_ANON_KEY", "a.b.c")
 os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "d.e.f")
 
 app = FastAPI()
-app.include_router(dump_router)
+app.include_router(dump_router, prefix="/api")
 
 client = TestClient(app)
 

--- a/api/tests/api/test_commits_endpoint.py
+++ b/api/tests/api/test_commits_endpoint.py
@@ -11,7 +11,7 @@ os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "d.e.f")
 from app.routes.commits import router as commits_router
 
 app = FastAPI()
-app.include_router(commits_router)
+app.include_router(commits_router, prefix="/api")
 
 client = TestClient(app)
 

--- a/api/tests/api/test_dump_endpoint.py
+++ b/api/tests/api/test_dump_endpoint.py
@@ -11,7 +11,7 @@ os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "d.e.f")
 from app.routes.dump import router as dump_router
 
 app = FastAPI()
-app.include_router(dump_router)
+app.include_router(dump_router, prefix="/api")
 
 client = TestClient(app)
 


### PR DESCRIPTION
## Summary
- mount all API routers under `/api`
- remove duplicate prefixes from individual route modules
- update tests to include the new `/api` prefix when mounting routers

## Testing
- `npm test`
- `make tests` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_684bd95b02fc832989589b8057342a83