### PR TITLE
Add API route smoke tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Allow test discovery to traverse package

--- a/tests/api/test_route_contracts.py
+++ b/tests/api/test_route_contracts.py
@@ -1,0 +1,23 @@
+import pytest
+import httpx
+
+BASE_URL = "http://localhost:10000"  # Adjust as needed for test env
+
+# Skip entire module if API server isn't reachable
+try:
+    httpx.get(BASE_URL, timeout=1)
+except Exception:
+    pytest.skip("API server not available", allow_module_level=True)
+
+@pytest.mark.parametrize("method, path", [
+    ("GET",    "/api/blocks"),
+    ("GET",    "/api/baskets/healthcheck"),  # Optional if you have health routes
+    ("POST",   "/api/agent-run"),
+    ("POST",   "/api/agent"),
+    ("POST",   "/api/agent/direct"),
+])
+def test_api_route_exists(method, path):
+    client = httpx.Client()
+    response = client.request(method, f"{BASE_URL}{path}")
+    assert response.status_code != 404, f"Route {method} {path} returned 404"
+    assert response.status_code < 500, f"Route {method} {path} caused server error"


### PR DESCRIPTION
## Summary
- add `tests/api/test_route_contracts.py` with HTTPX smoke tests
- add `tests/__init__.py` so pytest package discovery works

## Testing
- `PYTHONPATH=./api pytest -q tests/api/test_route_contracts.py tests/agent_tasks/test_apply_diffs.py tests/baskets tests/contracts tests/utils`

------
https://chatgpt.com/codex/tasks/task_e_684bdc47b0288329b3c286aeabc663f8