### PR TITLE
Add CI task template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+# ✅ Codex will generate this file after checking:
+# - python version from pyproject.toml
+# - use of poetry
+# - presence of ruff for linting
+# - pytest or make test usage
+# - whether env vars are required for tests
+
+# 🚀 After introspection, Codex will scaffold:
+# - Setup Python
+# - Install poetry
+# - Cache dependencies
+# - Run tests using correct commands
+# - Optionally run lint step if present
+# - Trigger only when relevant files change (api/**, tests/**, .github/workflows/**)
+
+# Codex: Begin with environment scan before writing CI config.

--- a/codex/tasks/ci/introspect_and_generate_optimized_ci.ts
+++ b/codex/tasks/ci/introspect_and_generate_optimized_ci.ts
@@ -1,0 +1,27 @@
+export default {
+  summary: "Introspect Python test environment and generate an optimized CI workflow",
+  scope: "api",
+  changes: [
+    {
+      file: ".github/workflows/ci.yml",
+      description: "Create a clean GitHub Actions workflow based on poetry, pytest, ruff, and API test structure",
+      content: `# ✅ Codex will generate this file after checking:
+# - python version from pyproject.toml
+# - use of poetry
+# - presence of ruff for linting
+# - pytest or make test usage
+# - whether env vars are required for tests
+
+# 🚀 After introspection, Codex will scaffold:
+# - Setup Python
+# - Install poetry
+# - Cache dependencies
+# - Run tests using correct commands
+# - Optionally run lint step if present
+# - Trigger only when relevant files change (api/**, tests/**, .github/workflows/**)
+
+# Codex: Begin with environment scan before writing CI config.
+`
+    }
+  ]
+};


### PR DESCRIPTION
## Summary
- add codex task to inspect Python setup and generate CI
- placeholder GitHub Actions workflow for Codex to overwrite later

## Testing
- `make tests` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684bdf587264832997504726f5335726