### PR TITLE
Add editable src setup and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,40 @@
-# ✅ Codex will generate this file after checking:
-# - python version from pyproject.toml
-# - use of poetry
-# - presence of ruff for linting
-# - pytest or make test usage
-# - whether env vars are required for tests
+name: CI - API Tests
 
-# 🚀 After introspection, Codex will scaffold:
-# - Setup Python
-# - Install poetry
-# - Cache dependencies
-# - Run tests using correct commands
-# - Optionally run lint step if present
-# - Trigger only when relevant files change (api/**, tests/**, .github/workflows/**)
+on:
+  push:
+    paths:
+      - 'api/**'
+      - 'tests/**'
+      - 'setup.py'
+      - '.github/workflows/ci.yml'
+  pull_request:
+    paths:
+      - 'api/**'
+      - 'tests/**'
+      - 'setup.py'
+      - '.github/workflows/ci.yml'
 
-# Codex: Begin with environment scan before writing CI config.
+jobs:
+  test-api:
+    runs-on: ubuntu-latest
+    name: Run API Tests
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies + src in editable mode
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]  # editable install via setup.py
+          pip install pytest
+
+      - name: Run Pytest
+        run: pytest -q --tb=short
+
+      # Optional: Add linting step here later if needed

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,2 +1,2 @@
 test:
-	PYTHONPATH=src pytest -q
+pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ build-backend = "hatchling.build"
 allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/app"]                    # ← path updated
+packages = ["api/src"]
 
 # -----------------------------------------------------------------
 # Tool configs

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="rightnow-agent-app",
+    version="0.0.9",
+    packages=find_packages(where="api"),
+    package_dir={"": "api"},
+    install_requires=[],
+    include_package_data=True,
+)


### PR DESCRIPTION
## Summary
- declare src as installable package via `setup.py`
- run tests in CI using editable install
- clean Makefile test command
- package all api/src modules via Hatch config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684be49d0fac8329830a3f836375a07b