### PR TITLE
Fix supabase imports

### DIFF
--- a/api/src/app/utils/__init__.py
+++ b/api/src/app/utils/__init__.py
@@ -1,8 +1,6 @@
-"""Provide access to the shared ``supabase_client`` utilities."""
+"""Utility helpers for the application layer."""
 
-from utils import supabase_client as _real
-
-supabase_client = _real  # re-export for backwards compatibility
+from .supabase_client import supabase_client
 
 __all__ = ["supabase_client"]
 

--- a/api/src/app/utils/supabase_client.py
+++ b/api/src/app/utils/supabase_client.py
@@ -1,12 +1,16 @@
-"""
-Proxy shim so `import src.app.utils.supabase_client` works when Render
-starts the server with:
-    uvicorn src.app.agent_server:app
-It forwards every public name to the real supabase_client module
-located at api/src/utils/supabase_client.py
-"""
+"""Local Supabase client used by application routes and tasks."""
 
-# Proxy to the real supabase_client module in ``src.utils``
-from utils.supabase_client import supabase_client
+import os
+
+from supabase import create_client
+
+
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+
+if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE_KEY:
+    raise RuntimeError("Supabase env vars missing")
+
+supabase_client = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 
 __all__ = ["supabase_client"]


### PR DESCRIPTION
## Summary
- remove shim indirection from `utils.supabase_client`
- use local Supabase client in app utils

## Testing
- `npm test`
- `env PYTHONPATH=api/src uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d5928b92c8329a1616d1fa5b10e9a