### PR TITLE
Cleanup agent entrypoints for Phase 1

### DIFF
--- a/api/src/app/agent_tasks/layer1_infra/utils/task_progress.py
+++ b/api/src/app/agent_tasks/layer1_infra/utils/task_progress.py
@@ -1,9 +1,19 @@
-"""
-Utility: task_progress
+"""Helpers for tracking task progress in Phase 1."""
+from dataclasses import dataclass
+from typing import Iterable, Any
 
-Helper to track task progress and identify missing input fields for a given task type.
-"""
-from ...layer2_tasks.registry.models import InputField, TaskType
+
+@dataclass
+class InputField:
+    """Minimal InputField placeholder."""
+    name: str
+
+
+@dataclass
+class TaskType:
+    """Minimal TaskType placeholder."""
+    id: str
+    input_fields: Iterable[InputField]
 
 
 def get_missing_fields(task_type: TaskType, current_inputs: dict) -> list[InputField]:
@@ -17,15 +27,3 @@ def get_missing_fields(task_type: TaskType, current_inputs: dict) -> list[InputF
         if value is None or (isinstance(value, str) and not value.strip()) or (isinstance(value, (list, dict)) and not value):
             missing.append(field)
     return missing
-
-def is_ready_to_dispatch(task_type_id: str, inputs: dict) -> bool:
-    """
-    Return True if no required input_fields are missing for the given task_type_id.
-    """
-    from ...layer2_tasks.registry import get_task_def as get_task_type
-
-    task_type = get_task_type(task_type_id)
-    if not task_type:
-        raise ValueError(f"Unknown task_type_id '{task_type_id}'")
-    missing = get_missing_fields(task_type, inputs)
-    return len(missing) == 0

--- a/api/src/app/routes/task_types.py
+++ b/api/src/app/routes/task_types.py
@@ -1,12 +1,14 @@
 """API route for listing available task types."""
 from fastapi import APIRouter
 
-from ..agent_tasks.layer2_tasks.registry import get_all_task_types
+# Phase 1 stub: no task types registered
+def get_all_task_types() -> list[dict]:
+    return []
 
 router = APIRouter(prefix="/task-types", tags=["task-types"])
 
 
 @router.get("/", response_model=list[dict])
 async def list_all():
-    """Return all registered TaskTypes."""
-    return [t.model_dump(mode="json") for t in get_all_task_types()]
+    """Return all registered TaskTypes. Phase 1 returns an empty list."""
+    return get_all_task_types()


### PR DESCRIPTION
## Summary
- strip phase2 imports from `agent_entrypoints`
- stub out payload building and task registry
- add helper `create_task_and_session`
- simplify task progress helpers
- return empty list for `/task-types`

## Testing
- `env PYTHONPATH=api/src uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d5dbafadc8329820d0a3c2d76889b