### PR TITLE
Improve NarrativeView robustness

### DIFF
--- a/web/__tests__/narrativeView.test.tsx
+++ b/web/__tests__/narrativeView.test.tsx
@@ -3,11 +3,13 @@ import NarrativeView from "@/components/work/NarrativeView";
 import { SWRConfig } from "swr";
 import React from "react";
 
+const mockUseInputs = vi.fn(() => ({
+  inputs: [{ id: "i1", content: "# Hello world" }],
+  isLoading: false,
+}));
+
 vi.mock("@/lib/baskets/useInputs", () => ({
-  useInputs: () => ({
-    inputs: [{ id: "i1", content: "# Hello world" }],
-    isLoading: false,
-  }),
+  useInputs: () => mockUseInputs(),
 }));
 vi.mock("@/lib/baskets/useBlocks", () => ({
   useBlocks: () => ({
@@ -45,4 +47,14 @@ it("shows highlight indicator", async () => {
     </SWRConfig>,
   );
   expect(await screen.findByTitle(/possible_redundancy/i)).toBeInTheDocument();
+});
+
+it("handles empty inputs gracefully", async () => {
+  mockUseInputs.mockReturnValueOnce({ inputs: [{ id: "i2", content: "" }], isLoading: false });
+  render(
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <NarrativeView basketId="b1" />
+    </SWRConfig>,
+  );
+  expect(await screen.findByText(/no narrative available/i)).toBeInTheDocument();
 });

--- a/web/components/work/NarrativeView.tsx
+++ b/web/components/work/NarrativeView.tsx
@@ -20,6 +20,8 @@ export default function NarrativeView({ basketId }: Props) {
   const { blocks } = useBlocks(basketId);
   const { highlights } = useHighlights(basketId);
 
+  const [hasSelection, setHasSelection] = React.useState(false);
+
   const handlePromote = async () => {
     const sel = window.getSelection()?.toString().trim();
     if (!sel) return;
@@ -32,6 +34,15 @@ export default function NarrativeView({ basketId }: Props) {
     });
     toast.success("Promoted to block");
   };
+
+  React.useEffect(() => {
+    const handleSelection = () => {
+      const sel = window.getSelection()?.toString().trim();
+      setHasSelection(!!sel);
+    };
+    document.addEventListener("selectionchange", handleSelection);
+    return () => document.removeEventListener("selectionchange", handleSelection);
+  }, []);
 
   const highlightMap = React.useMemo(() => {
     const map = new Map<string, string>();
@@ -79,14 +90,21 @@ export default function NarrativeView({ basketId }: Props) {
         size="sm"
         aria-label="Promote selected text"
         className="text-xs"
+        disabled={!hasSelection}
       >
         Promote Selection
       </Button>
       {inputs.map((i) => (
         <article key={i.id} className="prose max-w-none">
-          <ReactMarkdown remarkPlugins={[remarkGfm]} components={renderers}>
-            {i.content}
-          </ReactMarkdown>
+          {typeof i?.content === "string" && i.content.trim() ? (
+            <ReactMarkdown remarkPlugins={[remarkGfm]} components={renderers}>
+              {i.content}
+            </ReactMarkdown>
+          ) : (
+            <p className="text-sm italic text-muted-foreground">
+              No narrative available.
+            </p>
+          )}
         </article>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- prevent crashes in NarrativeView by guarding content rendering
- disable promote button when no text is selected
- add smoke test for missing input content

## Testing
- `npm test`
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_684d6774495c83299ca117df6cdecb0b