### PR TITLE
Defensive markdown rendering

### DIFF
--- a/web/__tests__/narrativeView.test.tsx
+++ b/web/__tests__/narrativeView.test.tsx
@@ -58,3 +58,14 @@ it("handles empty inputs gracefully", async () => {
   );
   expect(await screen.findByText(/no narrative available/i)).toBeInTheDocument();
 });
+
+it("handles malformed input without crashing", async () => {
+  // @ts-expect-error deliberately pass bad value
+  mockUseInputs.mockReturnValueOnce({ inputs: [{ id: "i3", content: undefined }], isLoading: false });
+  render(
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <NarrativeView basketId="b1" />
+    </SWRConfig>,
+  );
+  expect(await screen.findByText(/no narrative available/i)).toBeInTheDocument();
+});

--- a/web/components/work/NarrativeView.tsx
+++ b/web/components/work/NarrativeView.tsx
@@ -62,7 +62,7 @@ export default function NarrativeView({ basketId }: Props) {
           return (
             <>
               {txt.slice(0, idx)}
-                <span
+              <span
                 className="underline decoration-dotted decoration-yellow-600 underline-offset-2"
                 title={tip}
                 aria-label={tip}
@@ -77,6 +77,26 @@ export default function NarrativeView({ basketId }: Props) {
       return <>{txt}</>;
     },
   } as any;
+
+  const SafeMarkdown: React.FC<{ content: string }> = ({ content }) => {
+    try {
+      return (
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          components={renderers}
+        >
+          {content}
+        </ReactMarkdown>
+      );
+    } catch (err) {
+      console.error("Markdown render error", err);
+      return (
+        <p className="text-sm italic text-muted-foreground">
+          Failed to render content.
+        </p>
+      );
+    }
+  };
 
   if (isLoading) return <div className="p-6 text-sm">Loading…</div>;
   if (error) return <div className="p-6 text-sm text-red-500">Failed to load narrative.</div>;
@@ -97,9 +117,7 @@ export default function NarrativeView({ basketId }: Props) {
       {inputs.map((i) => (
         <article key={i.id} className="prose max-w-none">
           {typeof i?.content === "string" && i.content.trim() ? (
-            <ReactMarkdown remarkPlugins={[remarkGfm]} components={renderers}>
-              {i.content}
-            </ReactMarkdown>
+            <SafeMarkdown content={i.content} />
           ) : (
             <p className="text-sm italic text-muted-foreground">
               No narrative available.


### PR DESCRIPTION
## Summary
- guard <NarrativeView> markdown rendering with SafeMarkdown
- test malformed/undefined input cases

## Testing
- `npm test`
- `make tests`


------
https://chatgpt.com/codex/tasks/task_e_684d70ecc3a48329aeee853c3d7b7541