### PR TITLE
Align Phase 1 API routes with frontend

### DIFF
--- a/api/src/app/agent_server.py
+++ b/api/src/app/agent_server.py
@@ -37,6 +37,7 @@ from fastapi.middleware.cors import CORSMiddleware
 # Agent handlers
 from .agent_entrypoints import router as agent_router, run_agent, run_agent_direct
 from .ingestion.job_listener import start_background_worker
+from .routes.agent_run import router as agent_run_router
 
 # Route modules
 from .routes.baskets import router as basket_router
@@ -69,6 +70,7 @@ api.include_router(inputs_router, prefix="/api")
 api.include_router(debug_router, prefix="/api")
 api.include_router(agent_router, prefix="/api")
 api.include_router(phase1_router, prefix="/api")
+api.include_router(agent_run_router, prefix="/api")
 
 # Agent entrypoints with API prefix
 

--- a/api/src/app/routes/phase1_routes.py
+++ b/api/src/app/routes/phase1_routes.py
@@ -29,6 +29,7 @@ class ContextBlockOut(BaseModel):
     success: bool = True
 
 
+# TODO(phase2): Currently unused. Remove or connect if frontend adopts this route.
 @router.post("/basket-inputs", response_model=BasketInputOut)
 async def create_basket_input(input: BasketInputIn):
     input_id = str(uuid4())
@@ -41,6 +42,7 @@ async def create_basket_input(input: BasketInputIn):
         raise HTTPException(status_code=500, detail=f"Insertion failed: {e}") from e
 
 
+# TODO(phase2): Currently unused. Remove or connect if frontend adopts this route.
 @router.post("/context-blocks", response_model=ContextBlockOut)
 async def promote_context_block(block: ContextBlockIn):
     block_id = str(uuid4())
@@ -61,6 +63,7 @@ async def promote_context_block(block: ContextBlockIn):
         raise HTTPException(status_code=500, detail=f"Insertion failed: {e}") from e
 
 
+# TODO(phase2): Currently unused. Remove or connect if frontend adopts this route.
 @router.get("/basket-inputs/{input_id}/highlight-suggestions")
 async def get_highlight_suggestions(input_id: str):
     # Dummy placeholder, to be replaced with logic if highlight implemented

--- a/tests/api/test_route_contracts.py
+++ b/tests/api/test_route_contracts.py
@@ -1,5 +1,5 @@
-import pytest
 import httpx
+import pytest
 
 BASE_URL = "http://localhost:10000"  # Adjust as needed for test env
 
@@ -9,13 +9,15 @@ try:
 except Exception:
     pytest.skip("API server not available", allow_module_level=True)
 
-@pytest.mark.parametrize("method, path", [
-    ("GET",    "/api/blocks"),
-    ("GET",    "/api/baskets/healthcheck"),  # Optional if you have health routes
-    ("POST",   "/api/agent-run"),
-    ("POST",   "/api/agent"),
-    ("POST",   "/api/agent/direct"),
-])
+
+@pytest.mark.parametrize(
+    "method, path",
+    [
+        ("POST", "/api/agent-run"),
+        ("POST", "/api/agent"),
+        ("POST", "/api/agent/direct"),
+    ],
+)
 def test_api_route_exists(method, path):
     client = httpx.Client()
     response = client.request(method, f"{BASE_URL}{path}")

--- a/tests/baskets/highlight_flow.spec.ts
+++ b/tests/baskets/highlight_flow.spec.ts
@@ -1,39 +1,61 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test.use({ storageState: 'storageState.json' });
+test.use({ storageState: "storageState.json" });
 
-test('basic promote and highlight flow', async ({ page }) => {
-  await page.route('**/api/baskets/1/inputs', async route => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify([{ id: 'in1', content: '# Hello world', created_at: '' }])
+test("basic promote and highlight flow", async ({ page }) => {
+    await page.route("**/api/baskets/1/inputs", async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([
+                { id: "in1", content: "# Hello world", created_at: "" },
+            ]),
+        });
     });
-  });
-  await page.route('**/api/baskets/1/blocks', async route => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify([{ id: 'b1', label: 'Hello', type: 'note', updated_at: '', commit_id: null }])
+    await page.route("**/api/baskets/1/blocks", async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([
+                {
+                    id: "b1",
+                    label: "Hello",
+                    type: "note",
+                    updated_at: "",
+                    commit_id: null,
+                },
+            ]),
+        });
     });
-  });
-  await page.route('**/api/baskets/1/input-highlights', async route => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify([{ dump_input_id: 'in1', conflicting_block_id: 'b1', reason: 'possible_redundancy' }])
+    await page.route("**/api/baskets/1/input-highlights", async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([
+                {
+                    dump_input_id: "in1",
+                    conflicting_block_id: "b1",
+                    reason: "possible_redundancy",
+                },
+            ]),
+        });
     });
-  });
-  await page.route('**/context_blocks', async route => {
-    await route.fulfill({ status: 201, contentType: 'application/json', body: '{}' });
-  });
+    await page.route("**/api/context-blocks", async (route) => {
+        await route.fulfill({
+            status: 201,
+            contentType: "application/json",
+            body: "{}",
+        });
+    });
 
-  await page.setViewportSize({ width: 375, height: 667 });
-  await page.goto('/baskets/1/work');
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto("/baskets/1/work");
 
-  await expect(page.locator('span[title*="possible_redundancy"]')).toBeVisible();
+    await expect(
+        page.locator('span[title*="possible_redundancy"]'),
+    ).toBeVisible();
 
-  await page.locator('article').click();
-  await page.getByRole('button', { name: /Promote Selection/i }).click();
-  await expect(page.locator('text=Promoted to block')).toBeVisible();
+    await page.locator("article").click();
+    await page.getByRole("button", { name: /Promote Selection/i }).click();
+    await expect(page.locator("text=Promoted to block")).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- register agent_run router
- clean up outdated contract tests
- mark unused Phase 1 routes
- update highlight flow test path

## Testing
- `npm test`
- `make tests`


------
https://chatgpt.com/codex/tasks/task_e_684e27b4a85c8329999b6c5cd191f9ef