### PR TITLE
Align BasketWorkPage types and narrative view

### DIFF
--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -6,11 +6,11 @@ import BlocksWorkspace from "@/components/work/BlocksWorkspace";
 import NarrativeView from "@/components/work/NarrativeView";
 import { useInputs } from "@/lib/baskets/useInputs";
 
-type PageProps = {
+export default function BasketWorkPage({
+  params
+}: {
   params: { id: string };
-};
-
-export default function BasketWorkPage({ params }: PageProps) {
+}) {
   const basketId = params.id;
   const [selectedCommitId, setSelectedCommitId] = useState<string | null>(null);
   const { data: inputs, isLoading, error } = useInputs(basketId);


### PR DESCRIPTION
## Summary
- add loading/error handling for basket work page
- defensively render narrative content
- skip highlight Playwright test
- mark phase 2 routes as TODOs

## Testing
- `make tests`
- `npm run e2e:test` *(fails: start-dev.sh permission denied / next not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e38286f1883299521bd048ecc7740