### PR TITLE
Fix narrative content validation

### DIFF
--- a/web/components/work/NarrativeView.tsx
+++ b/web/components/work/NarrativeView.tsx
@@ -9,13 +9,15 @@ type NarrativeViewProps = {
 };
 
 export default function NarrativeView({ input }: NarrativeViewProps) {
-  if (!input || !input.content || input.content.trim() === "") {
+  const content = input?.content;
+
+  if (typeof content !== "string" || content.trim() === "") {
     return <p className="text-muted-foreground italic">No narrative available.</p>;
   }
 
   return (
     <ReactMarkdown remarkPlugins={[remarkGfm]}>
-      {input.content}
+      {content}
     </ReactMarkdown>
   );
 }


### PR DESCRIPTION
## Summary
- handle `input.content` that might be missing or not a string in `NarrativeView`

## Testing
- `npm --prefix web run build`
- `npm run e2e:test` *(fails: page.goto errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e51ff22548329952a7bd67fa9dfc0