### PR TITLE
Fix modal accessibility and markdown errors

### DIFF
--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -6,7 +6,11 @@ import BlocksWorkspace from "@/components/work/BlocksWorkspace";
 import NarrativeView from "@/components/work/NarrativeView";
 import { useInputs } from "@/lib/baskets/useInputs";
 
-export default function BasketWorkPage({ params }: any) {
+export default function BasketWorkPage({
+  params,
+}: {
+  params: { id: string };
+}) {
   const basketId = params.id;
   const [selectedCommitId, setSelectedCommitId] = useState<string | null>(null);
   const { inputs, isLoading, error } = useInputs(basketId);

--- a/web/components/DumpModal.tsx
+++ b/web/components/DumpModal.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
 import { Card, CardContent } from "@/components/ui/Card";
 import SmartDropZone from "@/components/SmartDropZone";
 import ThumbnailStrip from "@/components/ThumbnailStrip";
@@ -74,12 +80,14 @@ export default function DumpModal({ basketId: propBasketId, initialOpen = false 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Drop it. We’ll remember.</DialogTitle>
+          <DialogDescription>
+            Paste or drag text / screenshots. • Shortcut ⌘/Ctrl + Shift + V
+          </DialogDescription>
+        </DialogHeader>
         <Card className="max-w-2xl p-8 mx-auto">
           <CardContent className="space-y-4 p-0">
-            <h2 className="text-xl font-medium">Drop it. We’ll remember.</h2>
-            <p className="text-xs text-muted-foreground">
-              Paste or drag text / screenshots. • Shortcut ⌘/Ctrl + Shift + V
-            </p>
             <SmartDropZone
               value={text}
               onChange={(e) => setText(e.target.value)}

--- a/web/components/work/NarrativeView.tsx
+++ b/web/components/work/NarrativeView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -15,9 +15,16 @@ export default function NarrativeView({ input }: NarrativeViewProps) {
     return <p className="text-muted-foreground italic">No narrative available.</p>;
   }
 
-  return (
-    <ReactMarkdown remarkPlugins={[remarkGfm]}>
-      {content}
-    </ReactMarkdown>
-  );
+  const rendered = useMemo(() => {
+    try {
+      return (
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      );
+    } catch (err) {
+      console.error("Markdown render failed", err);
+      return <p className="text-red-600">Failed to render narrative content.</p>;
+    }
+  }, [content]);
+
+  return rendered;
 }


### PR DESCRIPTION
## Summary
- add dialog heading and description in `DumpModal`
- handle Markdown parsing errors gracefully
- type `BasketWorkPage` params

## Test plan
- `make tests`
- `make lint` *(fails: Import block unsorted)*
- `make format` *(fails: ruff could not fix all issues)*

------
https://chatgpt.com/codex/tasks/task_e_684ea1d061d8832986fcff3facd2809d