### PR TITLE
Refactor basket-create UI

### DIFF
--- a/web/app/baskets/create/page.tsx
+++ b/web/app/baskets/create/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Input } from "@/components/ui/Input";
 import { Button } from "@/components/ui/Button";
-import { Textarea } from "@/components/ui/Textarea";
+import SmartDropZone from "@/components/SmartDropZone";
 import { UploadArea } from "@/components/baskets/UploadArea";
 import { createBasketWithInput } from "@/lib/baskets/createBasketWithInput";
 import { toast } from "react-hot-toast";
@@ -11,14 +11,27 @@ import { toast } from "react-hot-toast";
 export default function BasketCreatePage() {
   const [dumpText, setDumpText] = useState("");
   const [name, setName] = useState("");
-  const [fileUrls, setFileUrls] = useState<string[]>([]);
+  const [files, setFiles] = useState<(File | string)[]>([]);
+  const [previewUrls, setPreviewUrls] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
 
+  useEffect(() => {
+    const urls = files.map((f) =>
+      typeof f === "string" ? f : URL.createObjectURL(f)
+    );
+    setPreviewUrls(urls);
+    return () => {
+      urls.forEach((u) => {
+        if (u.startsWith("blob:")) URL.revokeObjectURL(u);
+      });
+    };
+  }, [files]);
+
   const handleCreate = async () => {
-    if (!dumpText.trim() && fileUrls.length === 0) return;
+    if (!dumpText.trim()) return;
     setSubmitting(true);
     try {
-      const basket = await createBasketWithInput({ text: dumpText, files: fileUrls });
+      const basket = await createBasketWithInput({ text: dumpText, files });
       if (name.trim()) {
         // optional: update basket name if API exists
       }
@@ -33,30 +46,58 @@ export default function BasketCreatePage() {
 
   return (
     <div className="max-w-2xl mx-auto p-6 space-y-6">
-      <div className="text-center text-2xl font-brand">🧶 start a new thread</div>
+      <h1 className="text-center text-2xl font-brand">🧶 start a new thread</h1>
 
-      <Textarea
+      <Input
+        placeholder="Name this basket (optional)"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        disabled={submitting}
+      />
+
+      <h2 className="text-lg font-medium">What are we working on?</h2>
+
+      <SmartDropZone
         className={`min-h-[300px] w-full resize-y rounded-2xl border p-4 text-lg shadow-sm bg-muted/50 ${submitting ? "opacity-80" : ""}`}
         placeholder="Pour your thoughts, ideas, or goals here..."
         value={dumpText}
         onChange={(e) => setDumpText(e.target.value)}
         readOnly={submitting}
+        onImages={(imgs) => setFiles((prev) => [...prev, ...imgs])}
       />
 
-      <UploadArea
-        prefix="basket-draft"
-        maxFiles={5}
-        onUpload={(url) => setFileUrls((prev) => [...prev, url])}
-      />
-
-      <div className="flex flex-col gap-2">
-        <Input
-          placeholder="Name your basket (optional)"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          disabled={submitting}
+      <div className="space-y-2">
+        <UploadArea
+          prefix="basket-draft"
+          maxFiles={5}
+          onUpload={(url) => setFiles((prev) => [...prev, url])}
         />
-        <Button onClick={handleCreate} disabled={submitting || (!dumpText.trim() && fileUrls.length === 0)}>
+        <p className="text-xs text-muted-foreground">
+          You can also drag and drop files.
+        </p>
+
+        {previewUrls.length > 0 && (
+          <div className="flex flex-wrap gap-2 pt-1">
+            {previewUrls.map((u, idx) => (
+              <div key={idx} className="relative w-24 h-24 rounded overflow-hidden border bg-muted">
+                <img src={u} alt="upload" className="object-cover w-full h-full" />
+                <button
+                  type="button"
+                  onClick={() =>
+                    setFiles((prev) => prev.filter((_, i) => i !== idx))
+                  }
+                  className="absolute top-1 right-1 bg-white/70 hover:bg-white rounded-full w-5 h-5 flex items-center justify-center text-xs"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex justify-end">
+        <Button onClick={handleCreate} disabled={submitting || !dumpText.trim()}>
           {submitting ? "Creating…" : "Create Basket"}
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- rework /baskets/create page layout
- support paste uploads with SmartDropZone
- allow inline file previews with removal controls

## Testing
- `npm test`
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_684f69cf2df08329af11cc4c46f8103c