### PR TITLE
Align basket + block schema with canonical model

### DIFF
--- a/api/src/app/routes/blocks.py
+++ b/api/src/app/routes/blocks.py
@@ -13,11 +13,9 @@ def list_blocks(basket_id: str):
     try:
         resp = (
             supabase.table("context_blocks")
-            .select("id,label,type,updated_at,commit_id")
+            .select("id,type,content,order,meta_tags,origin,status")
             .eq("basket_id", basket_id)
-            .eq("is_draft", False)
-            .eq("is_superseded", False)
-            .order("updated_at", desc=True)
+            .order("order")
             .execute()
         )
         return resp.data  # type: ignore[attr-defined]

--- a/api/src/schemas/basket.py
+++ b/api/src/schemas/basket.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Optional, List
 from uuid import UUID
 
@@ -12,23 +11,11 @@ class Basket(BaseSchema):
 
     id: Optional[UUID] = None
     user_id: str
-    intent: Optional[str] = None
-    sub_instructions: Optional[str] = None
-    media: Optional[dict] = None
-    core_profile_data: Optional[dict] = None
-    created_at: Optional[datetime] = None
-    core_context_snapshot: Optional[dict] = None
-    is_draft: bool = True
-    is_published: bool = False
-    is_locked: bool = False
-    meta_emotional_tone: Optional[List[str]] = None
-    meta_scope: Optional[str] = None
-    meta_audience: Optional[str] = None
-    updated_at: Optional[datetime] = None
-    compilation_mode: str = "summary"
-    intent_summary: Optional[str] = None
-    status: str = "draft"
+    name: Optional[str] = None
     raw_dump: Optional[str] = None
+    status: str = "draft"
+    tags: Optional[List[str]] = None
+    commentary: Optional[str] = None
 
 
 class BasketOut(BaseSchema):
@@ -36,6 +23,9 @@ class BasketOut(BaseSchema):
 
     id: UUID
     status: Optional[str] = None
-    intent_summary: Optional[str] = None
+    name: Optional[str] = None
+    raw_dump: Optional[str] = None
+    tags: Optional[List[str]] = None
+    commentary: Optional[str] = None
     blocks: List[dict]
     configs: List[dict]

--- a/api/src/schemas/context_block.py
+++ b/api/src/schemas/context_block.py
@@ -12,28 +12,13 @@ class ContextBlock(BaseSchema):
     """Core schema for a single context block."""
 
     id: UUID | None = None
-    user_id: str
-    label: str
-    content: str | None = None
-    file_ids: list[str] | None = None
-    type: str = "text"
-    source: str = "parser"
-    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    is_primary: bool = True
-
-    # Optional DB fields
-    update_policy: str | None = None
-    meta_scope: str | None = None
-    meta_context_scope: str | None = None
-    meta_tags: list[str] | None = None
-    meta_emotional_tone: list[str] | None = None
-    meta_locale: str | None = None
-    tags: list[str] | None = None
-    # link straight back to its basket (added 2024-06-11)
     basket_id: UUID | None = None
-    is_draft: bool | None = None
-    commit_id: UUID | None = None
-    updated_at: datetime | None = None
+    type: str
+    content: str
+    status: str = "proposed"
+    order: int | None = None
+    meta_tags: list[str] | None = None
+    origin: str | None = None
 
     # --- pydantic-v1 JSON compat -----------------
     class Config:

--- a/supabase/migrations/001_refactor_baskets_blocks.sql
+++ b/supabase/migrations/001_refactor_baskets_blocks.sql
@@ -1,0 +1,99 @@
+BEGIN;
+
+-- New enums for canonical model
+CREATE TYPE public.basket_status_enum AS ENUM ('draft','in_progress','complete','archived');
+CREATE TYPE public.block_status_enum AS ENUM ('proposed','approved','rejected','locked');
+CREATE TYPE public.block_type_enum AS ENUM ('content','metadata','commentary');
+
+-- Add new basket columns
+ALTER TABLE public.baskets
+    ADD COLUMN name text,
+    ADD COLUMN tags text[],
+    ADD COLUMN commentary text;
+
+-- Convert basket status to enum and set default
+ALTER TABLE public.baskets
+    ALTER COLUMN status TYPE public.basket_status_enum USING status::public.basket_status_enum,
+    ALTER COLUMN status SET DEFAULT 'draft';
+
+-- Drop legacy basket columns
+ALTER TABLE public.baskets
+    DROP COLUMN IF EXISTS intent,
+    DROP COLUMN IF EXISTS sub_instructions,
+    DROP COLUMN IF EXISTS media,
+    DROP COLUMN IF EXISTS core_profile_data,
+    DROP COLUMN IF EXISTS created_at,
+    DROP COLUMN IF EXISTS core_context_snapshot,
+    DROP COLUMN IF EXISTS is_draft,
+    DROP COLUMN IF EXISTS is_published,
+    DROP COLUMN IF EXISTS is_locked,
+    DROP COLUMN IF EXISTS meta_emotional_tone,
+    DROP COLUMN IF EXISTS meta_scope,
+    DROP COLUMN IF EXISTS meta_audience,
+    DROP COLUMN IF EXISTS updated_at,
+    DROP COLUMN IF EXISTS compilation_mode,
+    DROP COLUMN IF EXISTS intent_summary;
+
+-- Context blocks adjustments
+ALTER TABLE public.context_blocks
+    RENAME COLUMN source TO origin;
+
+ALTER TABLE public.context_blocks
+    ALTER COLUMN origin TYPE text USING origin::text,
+    ALTER COLUMN type TYPE public.block_type_enum USING type::text::public.block_type_enum,
+    ALTER COLUMN status TYPE public.block_status_enum USING status::text::public.block_status_enum,
+    ALTER COLUMN status SET DEFAULT 'proposed';
+
+ALTER TABLE public.context_blocks
+    ADD COLUMN "order" integer;
+
+-- Drop legacy context block columns
+ALTER TABLE public.context_blocks
+    DROP COLUMN IF EXISTS user_id,
+    DROP COLUMN IF EXISTS label,
+    DROP COLUMN IF EXISTS version,
+    DROP COLUMN IF EXISTS created_at,
+    DROP COLUMN IF EXISTS file_ids,
+    DROP COLUMN IF EXISTS importance,
+    DROP COLUMN IF EXISTS meta_context_scope,
+    DROP COLUMN IF EXISTS meta_agent_notes,
+    DROP COLUMN IF EXISTS meta_derived_from,
+    DROP COLUMN IF EXISTS meta_refreshable,
+    DROP COLUMN IF EXISTS meta_embedding,
+    DROP COLUMN IF EXISTS meta_locale,
+    DROP COLUMN IF EXISTS meta_visibility,
+    DROP COLUMN IF EXISTS is_auto_generated,
+    DROP COLUMN IF EXISTS requires_user_review,
+    DROP COLUMN IF EXISTS last_refreshed_at,
+    DROP COLUMN IF EXISTS meta_emotional_tone,
+    DROP COLUMN IF EXISTS update_policy,
+    DROP COLUMN IF EXISTS feedback_score,
+    DROP COLUMN IF EXISTS last_used_successfully_at,
+    DROP COLUMN IF EXISTS is_primary,
+    DROP COLUMN IF EXISTS parent_block_id,
+    DROP COLUMN IF EXISTS artifact_ids,
+    DROP COLUMN IF EXISTS group_id,
+    DROP COLUMN IF EXISTS tags,
+    DROP COLUMN IF EXISTS meta_scope,
+    DROP COLUMN IF EXISTS is_draft,
+    DROP COLUMN IF EXISTS is_superseded,
+    DROP COLUMN IF EXISTS supersedes_block_id,
+    DROP COLUMN IF EXISTS commit_id,
+    DROP COLUMN IF EXISTS updated_at;
+
+-- Add FK for basket relationship
+ALTER TABLE public.context_blocks
+    ADD CONSTRAINT context_blocks_basket_id_fkey FOREIGN KEY (basket_id)
+        REFERENCES public.baskets(id) ON DELETE CASCADE;
+
+-- Remove legacy table
+DROP TABLE IF EXISTS public.block_brief_link CASCADE;
+
+-- Drop unused enums
+DROP TYPE IF EXISTS public.context_block_importance_enum;
+DROP TYPE IF EXISTS public.context_block_source_enum;
+DROP TYPE IF EXISTS public.context_block_status_enum;
+DROP TYPE IF EXISTS public.context_block_type_enum;
+DROP TYPE IF EXISTS public.context_block_update_policy_enum;
+
+COMMIT;

--- a/tests/contracts/test_basket_fk.py
+++ b/tests/contracts/test_basket_fk.py
@@ -7,6 +7,6 @@ from schemas.context_block import ContextBlock
 
 
 def test_basket_id_pass_through():
-    b = ContextBlock(label="demo", content="x", user_id="u", basket_id=uuid4())
+    b = ContextBlock(type="content", content="x", basket_id=uuid4())
     dumped = b.model_dump(exclude_none=True)
     assert "basket_id" in dumped

--- a/tests/contracts/test_contracts.py
+++ b/tests/contracts/test_contracts.py
@@ -57,7 +57,10 @@ def test_round_trip_basket_out():
         {
             "id": "00000000-0000-0000-0000-000000000000",
             "status": "draft",
-            "intent_summary": "demo",
+            "name": "demo",
+            "raw_dump": "demo text",
+            "tags": ["t"],
+            "commentary": None,
             "blocks": [],
             "configs": [],
         }
@@ -69,8 +72,8 @@ def test_round_trip_basket_out():
 def test_optional_fields_skip():
     raw = {
         "id": "00000000-0000-0000-0000-000000000000",
-        "user_id": "00000000-0000-0000-0000-000000000001",
-        "label": "t",
+        "basket_id": "00000000-0000-0000-0000-000000000001",
+        "type": "content",
         "content": "c",
     }
     data = ContextBlock.model_validate(raw)

--- a/web/app/baskets/[id]/page.tsx
+++ b/web/app/baskets/[id]/page.tsx
@@ -28,7 +28,7 @@ export default function BasketDetailPage({ params }: any) {
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-6">
       <h1 className="text-2xl font-bold">Basket Detail</h1>
-      <p><b>Intent:</b> {basket.intent_summary}</p>
+      <p><b>Name:</b> {basket.name}</p>
       <section>
         <h2 className="font-semibold">Blocks</h2>
         <ul className="list-disc pl-5 text-sm">

--- a/web/app/baskets/page.tsx
+++ b/web/app/baskets/page.tsx
@@ -30,12 +30,11 @@ export default function BasketsPage() {
     const term = search.toLowerCase();
     let arr = baskets.filter(
       (b) =>
-        b.intent_summary?.toLowerCase().includes(term) ||
-        b.raw_dump?.toLowerCase().includes(term)
+        b.name?.toLowerCase().includes(term) || b.raw_dump?.toLowerCase().includes(term)
     );
     if (sort === "alpha") {
       arr = [...arr].sort((a, b) =>
-        (a.intent_summary || "").localeCompare(b.intent_summary || "")
+        (a.name || "").localeCompare(b.name || "")
       );
     } else if (sort === "created") {
       arr = [...arr].sort(

--- a/web/components/BasketCard.tsx
+++ b/web/components/BasketCard.tsx
@@ -5,7 +5,7 @@ import { formatDistanceToNow, format } from "date-fns";
 export interface BasketCardProps {
   basket: {
     id: string;
-    intent_summary?: string | null;
+    name?: string | null;
     raw_dump?: string | null;
     updated_at?: string | null;
     created_at?: string | null;
@@ -29,7 +29,7 @@ export default function BasketCard({ basket }: BasketCardProps) {
     >
       <div className="flex justify-between">
         <h3 className="text-md font-semibold truncate">
-          🧺 {basket.intent_summary || "Untitled Basket"}
+          🧺 {basket.name || "Untitled Basket"}
         </h3>
         {updated && (
           <span className="text-xs text-muted-foreground">Updated {updated}</span>

--- a/web/lib/baskets/createBasketWithInput.ts
+++ b/web/lib/baskets/createBasketWithInput.ts
@@ -24,7 +24,7 @@ export async function createBasketWithInput({ text, files = [] }: BasketInputPay
   // Capture the first line as an "intent" snippet. This is lightweight metadata
   // saved with the basket for later enrichment. It does not alter the original
   // text and is not considered parsing or transformation.
-  const intent = text.split("\n")[0]?.slice(0, 100) || null;
+  const name = text.split("\n")[0]?.slice(0, 100) || null;
 
   const uploadedUrls: string[] = [];
   const fileIds: string[] = [];
@@ -72,9 +72,9 @@ export async function createBasketWithInput({ text, files = [] }: BasketInputPay
     .insert({
       user_id: userId,
       raw_dump: text,
-      intent,
-      media: uploadedUrls,
-      is_draft: true,
+      name,
+      status: "draft",
+      tags: [],
     })
     .select()
     .single();

--- a/web/lib/baskets/getAllBaskets.ts
+++ b/web/lib/baskets/getAllBaskets.ts
@@ -2,10 +2,11 @@ import { createClient } from "@/lib/supabaseClient";
 
 export interface BasketOverview {
   id: string;
-  intent_summary: string | null;
+  name: string | null;
   raw_dump: string | null;
-  updated_at: string | null;
-  created_at: string | null;
+  status: string | null;
+  tags: string[] | null;
+  commentary: string | null;
   blocks_count?: number | null;
 }
 
@@ -14,16 +15,17 @@ export async function getAllBaskets(): Promise<BasketOverview[]> {
   const { data, error } = await supabase
     .from("baskets")
     .select(
-      "id,intent_summary,raw_dump,updated_at,created_at,block_brief_link(count)"
+      "id,name,raw_dump,status,tags,commentary,context_blocks(count)"
     )
-    .order("updated_at", { ascending: false });
+    .order("id", { ascending: false });
   if (error) throw new Error(error.message);
   return (data ?? []).map((b: any) => ({
     id: b.id,
-    intent_summary: b.intent_summary,
+    name: b.name,
     raw_dump: b.raw_dump,
-    updated_at: b.updated_at,
-    created_at: b.created_at,
-    blocks_count: b.block_brief_link?.[0]?.count ?? 0,
+    status: b.status,
+    tags: b.tags,
+    commentary: b.commentary,
+    blocks_count: b.context_blocks?.[0]?.count ?? 0,
   }));
 }


### PR DESCRIPTION
## Summary
- add migration bringing `baskets` and `context_blocks` in line with BASKET_AND_BLOCK_MODEL
- simplify basket and block schemas
- adjust API routes to new columns
- update web helpers and components to use new fields
- drop legacy table and enums
- update tests for new schemas

## Testing
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_684fb90bca108329b5d4678704f4500e