### PR TITLE
Fix baskets page compile error by adding timestamps

### DIFF
--- a/web/lib/baskets/getAllBaskets.ts
+++ b/web/lib/baskets/getAllBaskets.ts
@@ -7,6 +7,8 @@ export interface BasketOverview {
   status: string | null;
   tags: string[] | null;
   commentary: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
   blocks_count?: number | null;
 }
 
@@ -15,7 +17,7 @@ export async function getAllBaskets(): Promise<BasketOverview[]> {
   const { data, error } = await supabase
     .from("baskets")
     .select(
-      "id,name,raw_dump,status,tags,commentary,context_blocks(count)"
+      "id,name,raw_dump,status,tags,commentary,created_at,updated_at,context_blocks(count)"
     )
     .order("id", { ascending: false });
   if (error) throw new Error(error.message);
@@ -26,6 +28,8 @@ export async function getAllBaskets(): Promise<BasketOverview[]> {
     status: b.status,
     tags: b.tags,
     commentary: b.commentary,
+    created_at: b.created_at,
+    updated_at: b.updated_at,
     blocks_count: b.context_blocks?.[0]?.count ?? 0,
   }));
 }


### PR DESCRIPTION
## Summary
- add optional `created_at` and `updated_at` fields to `BasketOverview`
- return timestamp fields from `getAllBaskets`

## Testing
- `npm run test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684fd1c1b2ec832991e7f1ed1b14ead0