### PR TITLE
Fix Supabase env vars

### DIFF
--- a/api/src/app/agent_tasks/layer1_infra/utils/auth_helpers.py
+++ b/api/src/app/agent_tasks/layer1_infra/utils/auth_helpers.py
@@ -12,8 +12,8 @@ from supabase import create_client
 # Set up Bearer token dependency and Supabase admin client
 bearer = HTTPBearer()
 SUPA = create_client(
-    os.getenv("SUPABASE_URL"),
-    os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    os.getenv("NEXT_PUBLIC_SUPABASE_URL"),
+    os.getenv("NEXT_PUBLIC_SUPABASE_ANON_KEY")
 )
 
 async def current_user_id(

--- a/api/src/app/agent_tasks/layer1_infra/utils/supabase_helpers.py
+++ b/api/src/app/agent_tasks/layer1_infra/utils/supabase_helpers.py
@@ -5,15 +5,15 @@ from uuid import uuid4
 from datetime import datetime
 from src.utils.db import json_safe
 
-SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+SUPABASE_URL = os.getenv("NEXT_PUBLIC_SUPABASE_URL")
+SUPABASE_ANON_KEY = os.getenv("NEXT_PUBLIC_SUPABASE_ANON_KEY")
 
-if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE_KEY:
+if not SUPABASE_URL or not SUPABASE_ANON_KEY:
     raise RuntimeError(
-        "SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set in the environment; otherwise Supabase cannot be initialised."
+        "NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY must be set in the environment; otherwise Supabase cannot be initialised."
     )
 
-supabase = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+supabase = create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
 
 def get_supabase() -> 'Client':
     """

--- a/api/src/app/routes/debug.py
+++ b/api/src/app/routes/debug.py
@@ -5,7 +5,9 @@ from fastapi import APIRouter, HTTPException
 
 from supabase import create_client
 
-supabase = create_client(getenv("SUPABASE_URL"), getenv("SUPABASE_ANON_KEY"))
+supabase = create_client(
+    getenv("NEXT_PUBLIC_SUPABASE_URL"), getenv("NEXT_PUBLIC_SUPABASE_ANON_KEY")
+)
 router = APIRouter(prefix="/debug", tags=["debug"])
 
 logger = logging.getLogger("uvicorn.error")

--- a/api/src/app/utils/supabase_client.py
+++ b/api/src/app/utils/supabase_client.py
@@ -5,12 +5,12 @@ import os
 from supabase import create_client
 
 
-SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+SUPABASE_URL = os.getenv("NEXT_PUBLIC_SUPABASE_URL")
+SUPABASE_ANON_KEY = os.getenv("NEXT_PUBLIC_SUPABASE_ANON_KEY")
 
-if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE_KEY:
+if not SUPABASE_URL or not SUPABASE_ANON_KEY:
     raise RuntimeError("Supabase env vars missing")
 
-supabase_client = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+supabase_client = create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
 
 __all__ = ["supabase_client"]

--- a/api/src/utils/supabase_client.py
+++ b/api/src/utils/supabase_client.py
@@ -2,10 +2,10 @@ import os
 
 from supabase import create_client
 
-SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+SUPABASE_URL = os.getenv("NEXT_PUBLIC_SUPABASE_URL")
+SUPABASE_ANON_KEY = os.getenv("NEXT_PUBLIC_SUPABASE_ANON_KEY")
 
-if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE_KEY:
+if not SUPABASE_URL or not SUPABASE_ANON_KEY:
     raise RuntimeError("Supabase env vars missing")
 
-supabase_client = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+supabase_client = create_client(SUPABASE_URL, SUPABASE_ANON_KEY)

--- a/api/tests/api/test_change_queue_endpoint.py
+++ b/api/tests/api/test_change_queue_endpoint.py
@@ -5,9 +5,8 @@ import uuid
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-os.environ.setdefault("SUPABASE_URL", "http://localhost")
-os.environ.setdefault("SUPABASE_ANON_KEY", "a.b.c")
-os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "d.e.f")
+os.environ.setdefault("NEXT_PUBLIC_SUPABASE_URL", "http://localhost")
+os.environ.setdefault("NEXT_PUBLIC_SUPABASE_ANON_KEY", "a.b.c")
 
 from app.routes.change_queue import router as queue_router
 

--- a/api/tests/api/test_commit_insertion.py
+++ b/api/tests/api/test_commit_insertion.py
@@ -7,9 +7,8 @@ from fastapi.testclient import TestClient
 
 from app.routes.dump import router as dump_router
 
-os.environ.setdefault("SUPABASE_URL", "http://localhost")
-os.environ.setdefault("SUPABASE_ANON_KEY", "a.b.c")
-os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "d.e.f")
+os.environ.setdefault("NEXT_PUBLIC_SUPABASE_URL", "http://localhost")
+os.environ.setdefault("NEXT_PUBLIC_SUPABASE_ANON_KEY", "a.b.c")
 
 app = FastAPI()
 app.include_router(dump_router, prefix="/api")

--- a/api/tests/api/test_commits_endpoint.py
+++ b/api/tests/api/test_commits_endpoint.py
@@ -5,9 +5,8 @@ import uuid
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-os.environ.setdefault("SUPABASE_URL", "http://localhost")
-os.environ.setdefault("SUPABASE_ANON_KEY", "a.b.c")
-os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "d.e.f")
+os.environ.setdefault("NEXT_PUBLIC_SUPABASE_URL", "http://localhost")
+os.environ.setdefault("NEXT_PUBLIC_SUPABASE_ANON_KEY", "a.b.c")
 from app.routes.commits import router as commits_router
 
 app = FastAPI()

--- a/api/tests/api/test_dump_endpoint.py
+++ b/api/tests/api/test_dump_endpoint.py
@@ -5,9 +5,8 @@ import uuid
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-os.environ.setdefault("SUPABASE_URL", "http://localhost")
-os.environ.setdefault("SUPABASE_ANON_KEY", "a.b.c")
-os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "d.e.f")
+os.environ.setdefault("NEXT_PUBLIC_SUPABASE_URL", "http://localhost")
+os.environ.setdefault("NEXT_PUBLIC_SUPABASE_ANON_KEY", "a.b.c")
 from app.routes.dump import router as dump_router
 
 app = FastAPI()

--- a/docs/basket_creation_flow.md
+++ b/docs/basket_creation_flow.md
@@ -104,6 +104,15 @@ All parsing and block promotion happen *after* basket creation, as part of the a
 
 ---
 
+## 🔧 Required Environment Variables
+
+Set the following variables in `.env.local` and your deployment provider so basket creation and file uploads work:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+
+---
+
 ## 📌 Usage
 
 This document serves as the canonical reference for basket creation flows.  

--- a/web/.env.sample
+++ b/web/.env.sample
@@ -1,3 +1,3 @@
 NEXT_PUBLIC_API_BASE=http://localhost:10000
 NEXT_PUBLIC_SUPABASE_URL=https://yourproject.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/web/README.md
+++ b/web/README.md
@@ -68,13 +68,13 @@ To configure your local development and production environments, create a `.env.
 NEXT_PUBLIC_API_BASE=http://localhost:10000
 # Supabase REST API URL (public)
 NEXT_PUBLIC_SUPABASE_URL=https://xyzcompany.supabase.co
-# Supabase Service Role Key (server only!)
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+# Supabase anonymous key for client calls
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 ```
 On your production host (e.g., Vercel), set the same variables in the project settings:
   • `NEXT_PUBLIC_API_BASE` → your Render backend URL (e.g. `https://yarnnn.com`)
   • `NEXT_PUBLIC_SUPABASE_URL` → your Supabase project URL
-  • `SUPABASE_SERVICE_ROLE_KEY` → your Supabase service role secret
+  • `NEXT_PUBLIC_SUPABASE_ANON_KEY` → your Supabase anonymous key
 After updating `NEXT_PUBLIC_API_BASE`, redeploy the frontend so route handlers
 use the new value. You can confirm by requesting `/api/baskets/<id>/change-queue`
 and checking that the backend logs show a GET request without a 500 error.

--- a/web/lib/supabase/server.ts
+++ b/web/lib/supabase/server.ts
@@ -2,15 +2,15 @@ import { createClient } from '@supabase/supabase-js';
 
 export function createServerClient() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-  if (!supabaseUrl || !serviceKey) {
+  if (!supabaseUrl || !anonKey) {
     throw new Error(
-      'Missing Supabase env vars: NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY'
+      'Missing Supabase env vars: NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY'
     );
   }
 
-  return createClient(supabaseUrl, serviceKey, {
+  return createClient(supabaseUrl, anonKey, {
     auth: { persistSession: false, autoRefreshToken: false },
   });
 }


### PR DESCRIPTION
## Summary
- remove legacy SUPABASE env usage
- use NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY everywhere
- document required env vars for basket creation

## Testing
- `make lint` *(fails: import ordering issues)*
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_685006f71a7883298f53130faab0f4fa