### PR TITLE
Add canonical Supabase env var guide

### DIFF
--- a/api/src/app/agent_tasks/layer1_infra/utils/auth_helpers.py
+++ b/api/src/app/agent_tasks/layer1_infra/utils/auth_helpers.py
@@ -12,8 +12,8 @@ from supabase import create_client
 # Set up Bearer token dependency and Supabase admin client
 bearer = HTTPBearer()
 SUPA = create_client(
-    os.getenv("NEXT_PUBLIC_SUPABASE_URL"),
-    os.getenv("NEXT_PUBLIC_SUPABASE_ANON_KEY")
+    os.getenv("SUPABASE_URL"),
+    os.getenv("SUPABASE_SERVICE_ROLE_KEY")
 )
 
 async def current_user_id(

--- a/api/src/app/agent_tasks/layer1_infra/utils/supabase_helpers.py
+++ b/api/src/app/agent_tasks/layer1_infra/utils/supabase_helpers.py
@@ -5,15 +5,15 @@ from uuid import uuid4
 from datetime import datetime
 from src.utils.db import json_safe
 
-SUPABASE_URL = os.getenv("NEXT_PUBLIC_SUPABASE_URL")
-SUPABASE_ANON_KEY = os.getenv("NEXT_PUBLIC_SUPABASE_ANON_KEY")
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
 
-if not SUPABASE_URL or not SUPABASE_ANON_KEY:
+if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE_KEY:
     raise RuntimeError(
-        "NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY must be set in the environment; otherwise Supabase cannot be initialised."
+        "SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set in the environment; otherwise Supabase cannot be initialised."
     )
 
-supabase = create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
+supabase = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 
 def get_supabase() -> 'Client':
     """

--- a/api/src/app/routes/debug.py
+++ b/api/src/app/routes/debug.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, HTTPException
 from supabase import create_client
 
 supabase = create_client(
-    getenv("NEXT_PUBLIC_SUPABASE_URL"), getenv("NEXT_PUBLIC_SUPABASE_ANON_KEY")
+    getenv("SUPABASE_URL"), getenv("SUPABASE_SERVICE_ROLE_KEY")
 )
 router = APIRouter(prefix="/debug", tags=["debug"])
 

--- a/api/src/app/utils/supabase_client.py
+++ b/api/src/app/utils/supabase_client.py
@@ -5,12 +5,12 @@ import os
 from supabase import create_client
 
 
-SUPABASE_URL = os.getenv("NEXT_PUBLIC_SUPABASE_URL")
-SUPABASE_ANON_KEY = os.getenv("NEXT_PUBLIC_SUPABASE_ANON_KEY")
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
 
-if not SUPABASE_URL or not SUPABASE_ANON_KEY:
+if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE_KEY:
     raise RuntimeError("Supabase env vars missing")
 
-supabase_client = create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
+supabase_client = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 
 __all__ = ["supabase_client"]

--- a/api/src/utils/event_log.py
+++ b/api/src/utils/event_log.py
@@ -5,7 +5,7 @@ from supabase import create_client
 
 from .db import json_safe
 
-supabase = create_client(getenv("SUPABASE_URL"), getenv("SUPABASE_ANON_KEY"))
+supabase = create_client(getenv("SUPABASE_URL"), getenv("SUPABASE_SERVICE_ROLE_KEY"))
 
 
 async def log_event(

--- a/api/src/utils/supabase_client.py
+++ b/api/src/utils/supabase_client.py
@@ -2,10 +2,10 @@ import os
 
 from supabase import create_client
 
-SUPABASE_URL = os.getenv("NEXT_PUBLIC_SUPABASE_URL")
-SUPABASE_ANON_KEY = os.getenv("NEXT_PUBLIC_SUPABASE_ANON_KEY")
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
 
-if not SUPABASE_URL or not SUPABASE_ANON_KEY:
+if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE_KEY:
     raise RuntimeError("Supabase env vars missing")
 
-supabase_client = create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
+supabase_client = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)

--- a/api/tests/api/test_change_queue_endpoint.py
+++ b/api/tests/api/test_change_queue_endpoint.py
@@ -5,8 +5,8 @@ import uuid
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-os.environ.setdefault("NEXT_PUBLIC_SUPABASE_URL", "http://localhost")
-os.environ.setdefault("NEXT_PUBLIC_SUPABASE_ANON_KEY", "a.b.c")
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "svc.key")
 
 from app.routes.change_queue import router as queue_router
 

--- a/api/tests/api/test_commit_insertion.py
+++ b/api/tests/api/test_commit_insertion.py
@@ -7,8 +7,8 @@ from fastapi.testclient import TestClient
 
 from app.routes.dump import router as dump_router
 
-os.environ.setdefault("NEXT_PUBLIC_SUPABASE_URL", "http://localhost")
-os.environ.setdefault("NEXT_PUBLIC_SUPABASE_ANON_KEY", "a.b.c")
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "svc.key")
 
 app = FastAPI()
 app.include_router(dump_router, prefix="/api")

--- a/api/tests/api/test_commits_endpoint.py
+++ b/api/tests/api/test_commits_endpoint.py
@@ -5,8 +5,8 @@ import uuid
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-os.environ.setdefault("NEXT_PUBLIC_SUPABASE_URL", "http://localhost")
-os.environ.setdefault("NEXT_PUBLIC_SUPABASE_ANON_KEY", "a.b.c")
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "svc.key")
 from app.routes.commits import router as commits_router
 
 app = FastAPI()

--- a/api/tests/api/test_dump_endpoint.py
+++ b/api/tests/api/test_dump_endpoint.py
@@ -5,8 +5,8 @@ import uuid
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-os.environ.setdefault("NEXT_PUBLIC_SUPABASE_URL", "http://localhost")
-os.environ.setdefault("NEXT_PUBLIC_SUPABASE_ANON_KEY", "a.b.c")
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "svc.key")
 from app.routes.dump import router as dump_router
 
 app = FastAPI()

--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -67,6 +67,7 @@ Naming is always prefixed by purpose: orch_, tasks_, infra_
 Orchestration always starts at /api/agent, no matter the flow
 Supabase remains the single source of truth for memory data
 Codex supports dev workflows via declarative task files
+Supabase environment variables must follow [docs/env_supabase_reference.md](../docs/env_supabase_reference.md)
 This document reflects Phase 1’s focus on narrative-first preservation, downstream modularity on demand, and assistive—not intrusive—agents. It should remain durable as we evolve.
 
 # 📝 Summary

--- a/docs/basket_creation_flow.md
+++ b/docs/basket_creation_flow.md
@@ -106,10 +106,7 @@ All parsing and block promotion happen *after* basket creation, as part of the a
 
 ## 🔧 Required Environment Variables
 
-Set the following variables in `.env.local` and your deployment provider so basket creation and file uploads work:
-
-- `NEXT_PUBLIC_SUPABASE_URL`
-- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+Basket creation relies on the frontend Supabase keys. See [env_supabase_reference.md](env_supabase_reference.md) for the canonical list and guidance.
 
 ---
 

--- a/docs/env_supabase_reference.md
+++ b/docs/env_supabase_reference.md
@@ -1,0 +1,41 @@
+# Supabase Environment Variables
+
+This guide defines all Supabase related environment variables used in **yarnnn**.  Follow these definitions to avoid configuration drift between the frontend and backend.
+
+## Frontend variables
+
+These are injected into the browser bundle and must contain **least privilege** keys.
+
+| Variable | Purpose |
+| --- | --- |
+| `NEXT_PUBLIC_SUPABASE_URL` | Base URL for your Supabase project. Used by browser clients. |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Anonymous key for browser access. |
+
+## Backend variables
+
+These are only used on the server and **must never** be exposed to client code.
+
+| Variable | Purpose |
+| --- | --- |
+| `SUPABASE_URL` | Base URL for backend ingestion jobs and worker processes. |
+| `SUPABASE_SERVICE_ROLE_KEY` | Service role key with elevated privileges. |
+
+## Rules
+
+- Never expose `SUPABASE_SERVICE_ROLE_KEY` in client-side code or logs.
+- Backend modules should authenticate with `SUPABASE_SERVICE_ROLE_KEY`.
+- Frontend modules should use `NEXT_PUBLIC_SUPABASE_ANON_KEY` only.
+- Write RLS policies assuming the anon key for clients and the service role key for servers.
+
+## Deployment checklist
+
+- Ensure your Render or Vercel environment includes all of the keys above.
+- PR reviewers must verify that Supabase environment variables match this document.
+
+## Boundary diagram
+
+```
+[Browser] -- anon key --> [Backend API] -- service role key --> [Supabase]
+```
+
+This file is the single source of truth for Supabase environment variable usage.


### PR DESCRIPTION
## Summary
- document Supabase env vars in `docs/env_supabase_reference.md`
- link new reference from basket creation flow doc
- mention reference in codex/AGENTS.md
- switch backend code to SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY
- update tests for new env vars

## Testing
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_685093c0d8bc832995d0c8b3d4fc44b7