### PR TITLE
Add Supabase key role logging and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing to yarnnn
+
+Please run `make lint`, `make format`, and `make tests` before opening a pull request.
+
+When changing Supabase keys or environment variables, start the backend and confirm the ingestion worker logs:
+
+```
+[SUPABASE DEBUG] Loaded Supabase key role: service_role
+```
+
+If you see a different role, your deployment is misconfigured and will fail with permission errors.
+

--- a/api/src/app/utils/supabase_client.py
+++ b/api/src/app/utils/supabase_client.py
@@ -1,9 +1,13 @@
 """Local Supabase client used by application routes and tasks."""
 
+import logging
 import os
+
+import jwt
 
 from supabase import create_client
 
+logger = logging.getLogger(__name__)
 
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
@@ -11,6 +15,23 @@ SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
 if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE_KEY:
     raise RuntimeError("Supabase env vars missing")
 
+
+def _decode_key_role(key: str) -> str:
+    try:
+        decoded = jwt.decode(key, options={"verify_signature": False})
+    except Exception:  # noqa: BLE001
+        return "UNKNOWN"
+    return decoded.get("role", "UNKNOWN")
+
+
 supabase_client = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 
-__all__ = ["supabase_client"]
+SUPABASE_KEY_ROLE = _decode_key_role(SUPABASE_SERVICE_ROLE_KEY)
+logger.info("[SUPABASE DEBUG] Loaded Supabase key role: %s", SUPABASE_KEY_ROLE)
+if SUPABASE_KEY_ROLE != "service_role":
+    logger.error(
+        "[SUPABASE ERROR] Invalid key role loaded: %s. This may cause permission errors.",
+        SUPABASE_KEY_ROLE,
+    )
+
+__all__ = ["supabase_client", "_decode_key_role", "SUPABASE_KEY_ROLE"]

--- a/docs/env_supabase_reference.md
+++ b/docs/env_supabase_reference.md
@@ -47,3 +47,16 @@ If you see errors like `permission denied for schema public`, double-check that
 sufficient privileges. These errors typically mean the backend is using the
 anon key or an incorrect role.
 
+## Runtime Role Validation
+
+The ingestion worker decodes the `SUPABASE_SERVICE_ROLE_KEY` at startup and logs
+the `role` claim. You should see a log line similar to:
+
+```
+[SUPABASE DEBUG] Loaded Supabase key role: service_role
+```
+
+If the logged role is anything other than `service_role`, the backend will lack
+the required permissions and will raise errors like `permission denied for schem
+a public`.
+

--- a/tests/utils/test_supabase_role.py
+++ b/tests/utils/test_supabase_role.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+import jwt
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../api/src"))
+
+from app.utils.supabase_client import _decode_key_role
+
+
+def test_decode_key_role():
+    token = jwt.encode({"role": "service_role"}, "secret", algorithm="HS256")
+    assert _decode_key_role(token) == "service_role"


### PR DESCRIPTION
## Summary
- add runtime role check in ingestion worker
- log Supabase key role when client loads
- document runtime role validation
- note role log check in CONTRIBUTING guide
- test role decoding utility

## Testing
- `uv run ruff check api/src/app/utils/supabase_client.py api/src/app/ingestion/job_listener.py tests/utils/test_supabase_role.py`
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_6850cfcdcd0883298f08e746c1c14dce