### PR TITLE
Add runtime Supabase role check to ingestion worker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,12 @@
 
 Please run `make lint`, `make format`, and `make tests` before opening a pull request.
 
-When changing Supabase keys or environment variables, start the backend and confirm the ingestion worker logs:
+When changing Supabase keys or environment variables, start the backend and
+confirm the ingestion worker logs:
 
 ```
-[SUPABASE DEBUG] Loaded Supabase key role: service_role
+[DEBUG] Ingestion worker startup check: decoding Supabase key role.
+[SUPABASE DEBUG] Loaded Supabase key role at runtime: service_role
 ```
 
 If you see a different role, your deployment is misconfigured and will fail with permission errors.

--- a/api/src/app/ingestion/job_listener.py
+++ b/api/src/app/ingestion/job_listener.py
@@ -14,9 +14,10 @@ import threading
 import time
 from typing import Any
 
+import jwt
+
 from ..utils.supabase_client import (
     SUPABASE_SERVICE_ROLE_KEY,
-    _decode_key_role,
     supabase_client as supabase,
 )
 
@@ -91,11 +92,13 @@ logger = logging.getLogger(__name__)
 def start_background_worker() -> None:
     """Launch the ingestion worker thread."""
 
-    role = _decode_key_role(SUPABASE_SERVICE_ROLE_KEY)
-    logger.info("[SUPABASE DEBUG] Loaded Supabase key role: %s", role)
+    logger.info("[DEBUG] Ingestion worker startup check: decoding Supabase key role.")
+    decoded = jwt.decode(SUPABASE_SERVICE_ROLE_KEY, options={"verify_signature": False})
+    role = decoded.get("role", "UNKNOWN")
+    logger.info("[SUPABASE DEBUG] Loaded Supabase key role at runtime: %s", role)
     if role != "service_role":
         logger.error(
-            "[SUPABASE ERROR] Invalid key role loaded: %s. This may cause permission errors.",
+            "[SUPABASE ERROR] Invalid key role loaded at runtime: %s. This will cause permission errors.",
             role,
         )
 

--- a/docs/env_supabase_reference.md
+++ b/docs/env_supabase_reference.md
@@ -50,10 +50,11 @@ anon key or an incorrect role.
 ## Runtime Role Validation
 
 The ingestion worker decodes the `SUPABASE_SERVICE_ROLE_KEY` at startup and logs
-the `role` claim. You should see a log line similar to:
+the `role` claim. At startup you should see debug lines similar to:
 
 ```
-[SUPABASE DEBUG] Loaded Supabase key role: service_role
+[DEBUG] Ingestion worker startup check: decoding Supabase key role.
+[SUPABASE DEBUG] Loaded Supabase key role at runtime: service_role
 ```
 
 If the logged role is anything other than `service_role`, the backend will lack

--- a/tests/utils/test_supabase_client.py
+++ b/tests/utils/test_supabase_client.py
@@ -1,0 +1,23 @@
+import importlib
+import os
+import sys
+from unittest import mock
+
+import jwt
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../api/src"))
+
+
+@mock.patch("supabase.create_client")
+def test_supabase_client_uses_service_role(mock_create):
+    url = "http://example.com"
+    key = jwt.encode({"role": "service_role"}, "secret", algorithm="HS256")
+    os.environ["SUPABASE_URL"] = url
+    os.environ["SUPABASE_SERVICE_ROLE_KEY"] = key
+
+    if "app.utils.supabase_client" in sys.modules:
+        del sys.modules["app.utils.supabase_client"]
+    mod = importlib.import_module("app.utils.supabase_client")
+
+    mock_create.assert_called_with(url, key)
+    assert mod.SUPABASE_KEY_ROLE == "service_role"


### PR DESCRIPTION
## Summary
- log Supabase key role when starting ingestion worker
- document Supabase runtime role check
- clarify CONTRIBUTING instructions
- test that backend uses the service role key for the Supabase client

## Testing
- `make tests`
- `make lint` *(fails: F821 Undefined name errors)*

------
https://chatgpt.com/codex/tasks/task_e_6850d6959d4883298655206df7942b81