### PR TITLE
Fix FastAPI startup and add env check

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ You can verify the configuration by requesting /api/baskets/<id>/change-queue; t
 
 The /agent endpoint handles agent requests and remains stable across deployments.
 
+When deploying on Render, ensure the `SUPABASE_SERVICE_ROLE_KEY` environment
+variable is set. Without it, Supabase requests will fail.
+
 ## Repository Layout
 
 api/   FastAPI backend

--- a/api/src/app/agent_server.py
+++ b/api/src/app/agent_server.py
@@ -40,7 +40,6 @@ from .routes.agent_run import router as agent_run_router
 from .routes.agents import router as agents_router
 from .routes.basket_snapshot import router as snapshot_router
 
-
 # Route modules
 from .routes.baskets import router as basket_router
 from .routes.blocks import router as blocks_router
@@ -57,7 +56,6 @@ CHAT_URL = os.getenv("BUBBLE_CHAT_URL")
 
 # ── FastAPI app ────────────────────────────────────────────────────────────
 app = FastAPI(title="RightNow Agent Server")
-start_background_worker()
 
 # ── Unified API mounting ────────────────────────────────────────────────
 api = FastAPI()
@@ -94,6 +92,8 @@ app.mount("", api)
 
 # Logger for instrumentation
 logger = logging.getLogger("uvicorn.error")
+if "SUPABASE_SERVICE_ROLE_KEY" not in os.environ:
+    logger.warning("SUPABASE_SERVICE_ROLE_KEY not set; Supabase operations may fail")
 
 
 @app.get("/", include_in_schema=False)


### PR DESCRIPTION
## Summary
- remove defunct ingestion worker call when app starts
- warn if `SUPABASE_SERVICE_ROLE_KEY` is missing
- document Render env var requirement

## Testing
- `uv run ruff check api/src/app/agent_server.py`
- `uv run pytest` *(fails: ModuleNotFoundError: asyncpg)*

------
https://chatgpt.com/codex/tasks/task_e_68523f6836288329acd2ea701ee57cf2