### PR TITLE
Enable basket creation via POST

### DIFF
--- a/api/src/app/agent_server.py
+++ b/api/src/app/agent_server.py
@@ -49,6 +49,7 @@ from .routes.debug import router as debug_router
 from .routes.dump import router as dump_router
 from .routes.inputs import router as inputs_router
 from .routes.phase1_routes import router as phase1_router
+from .routes.basket_new import router as basket_new_router
 
 # ── Environment variable for Bubble webhook URL
 CHAT_URL = os.getenv("BUBBLE_CHAT_URL")
@@ -89,6 +90,7 @@ async def api_run_agent_direct(request):
 
 # Mount the grouped API to root
 app.mount("", api)
+app.include_router(basket_new_router)
 
 # Logger for instrumentation
 logger = logging.getLogger("uvicorn.error")

--- a/api/src/app/routes/basket_new.py
+++ b/api/src/app/routes/basket_new.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from uuid import uuid4
+
+from ..utils.supabase_client import supabase_client as supabase
+from utils.db import json_safe
+
+router = APIRouter(prefix="/api/baskets", tags=["baskets"])
+
+
+class BasketCreatePayload(BaseModel):
+    text_dump: str
+    file_urls: list[str] | None = None
+    basket_name: str | None = None
+
+
+@router.post("/new", status_code=201)
+async def create_basket(payload: BasketCreatePayload):
+    basket_id = str(uuid4())
+    try:
+        supabase.table("baskets").insert(
+            json_safe({"id": basket_id, "name": payload.basket_name})
+        ).execute()
+        supabase.table("raw_dumps").insert(
+            json_safe(
+                {
+                    "id": str(uuid4()),
+                    "basket_id": basket_id,
+                    "body_md": payload.text_dump,
+                    "file_refs": payload.file_urls or [],
+                }
+            )
+        ).execute()
+    except Exception:
+        raise HTTPException(status_code=500, detail="internal error")
+    return {"basket_id": basket_id}

--- a/api/tests/api/test_basket_new.py
+++ b/api/tests/api/test_basket_new.py
@@ -1,0 +1,38 @@
+import os
+import types
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "svc.key")
+
+from app.routes.basket_new import router as basket_new_router
+
+app = FastAPI()
+app.include_router(basket_new_router)
+client = TestClient(app)
+
+
+def _fake_table(name, store):
+    def insert(row):
+        store[name].append(row)
+        return types.SimpleNamespace(execute=lambda: None)
+
+    return types.SimpleNamespace(insert=insert)
+
+
+def test_basket_new(monkeypatch):
+    store = {"baskets": [], "raw_dumps": []}
+    fake = types.SimpleNamespace(table=lambda n: _fake_table(n, store))
+    monkeypatch.setattr("app.routes.basket_new.supabase", fake)
+
+    resp = client.post(
+        "/api/baskets/new",
+        json={"text_dump": "hello", "file_urls": ["f"], "basket_name": "test"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["basket_id"]
+    assert len(store["baskets"]) == 1
+    assert len(store["raw_dumps"]) == 1


### PR DESCRIPTION
## Summary
- add a `/api/baskets/new` POST route for creating baskets
- register new router with the FastAPI server
- test basket creation endpoint

## Testing
- `PYTHONPATH=api/src uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852431df6688329a1459ec635c7eac6