### PR TITLE
Add json_safe helper under app/util

### DIFF
--- a/api/src/app/routes/basket_new.py
+++ b/api/src/app/routes/basket_new.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 from uuid import uuid4
 
 from ..utils.supabase_client import supabase_client as supabase
-from utils.db import json_safe
+from ..util.db import json_safe
 
 router = APIRouter(prefix="/api/baskets", tags=["baskets"])
 

--- a/api/src/app/util/db.py
+++ b/api/src/app/util/db.py
@@ -1,0 +1,9 @@
+from datetime import datetime
+from uuid import UUID
+
+
+def json_safe(value):
+    """Cast UUID / datetime → str so Supabase python-client can JSON-dump."""
+    if isinstance(value, (UUID, datetime)):
+        return str(value)
+    return value


### PR DESCRIPTION
## Summary
- add `json_safe` utility for Supabase serialization
- use new helper from `basket_new`

## Testing
- `uv run black .`
- `uv run ruff check`
- `PYTHONPATH=api/src uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_685246e874d483298c50ff7cd512f1b2