### PR TITLE
Unify FastAPI router mounting & fix 405 on /api/baskets/new

### DIFF
--- a/api/src/app/agent_server.py
+++ b/api/src/app/agent_server.py
@@ -58,39 +58,36 @@ CHAT_URL = os.getenv("BUBBLE_CHAT_URL")
 # ── FastAPI app ────────────────────────────────────────────────────────────
 app = FastAPI(title="RightNow Agent Server")
 
-# ── Unified API mounting ────────────────────────────────────────────────
-api = FastAPI()
+routers = (
+    dump_router,
+    commits_router,
+    blocks_router,
+    change_queue_router,
+    basket_router,
+    basket_new_router,
+    snapshot_router,
+    inputs_router,
+    debug_router,
+    agent_router,
+    agent_run_router,
+    agents_router,
+    phase1_router,
+)
 
-# Route group under /api
-api.include_router(dump_router, prefix="/api")
-api.include_router(commits_router, prefix="/api")
-api.include_router(blocks_router, prefix="/api")
-api.include_router(change_queue_router, prefix="/api")
-api.include_router(basket_router, prefix="/api")
-api.include_router(snapshot_router, prefix="/api")
-api.include_router(inputs_router, prefix="/api")
-api.include_router(debug_router, prefix="/api")
-api.include_router(agent_router, prefix="/api")
-api.include_router(phase1_router, prefix="/api")
-api.include_router(agent_run_router, prefix="/api")
-api.include_router(agents_router, prefix="/api")
+for r in routers:
+    app.include_router(r, prefix="/api")
 
 # Agent entrypoints with API prefix
 
 
-@api.post("/api/agent")
+@app.post("/api/agent")
 async def api_run_agent(request):
     return await run_agent(request)
 
 
-@api.post("/api/agent/direct")
+@app.post("/api/agent/direct")
 async def api_run_agent_direct(request):
     return await run_agent_direct(request)
-
-
-# Mount the grouped API to root
-app.mount("", api)
-app.include_router(basket_new_router)
 
 # Logger for instrumentation
 logger = logging.getLogger("uvicorn.error")
@@ -99,7 +96,7 @@ if "SUPABASE_SERVICE_ROLE_KEY" not in os.environ:
 
 
 @app.get("/", include_in_schema=False)
-async def root():  # pragma: no cover
+async def health():  # pragma: no cover
     return {"status": "ok"}
 
 

--- a/api/src/app/routes/basket_new.py
+++ b/api/src/app/routes/basket_new.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 from ..utils.supabase_client import supabase_client as supabase
 from ..util.db import json_safe
 
-router = APIRouter(prefix="/api/baskets", tags=["baskets"])
+router = APIRouter(prefix="/baskets", tags=["baskets"])
 
 
 class BasketCreatePayload(BaseModel):

--- a/web/lib/baskets/createBasketNew.ts
+++ b/web/lib/baskets/createBasketNew.ts
@@ -1,11 +1,24 @@
-import { apiPost } from '@/lib/api';
-
 export interface NewBasketArgs {
   text: string;
   files?: string[];
   name?: string | null;
 }
-
-export async function createBasketNew(args: NewBasketArgs): Promise<{ id: string }> {
-  return apiPost('/api/baskets/new', args);
+export async function createBasketNew(
+  args: NewBasketArgs,
+): Promise<{ id: string }> {
+  const res = await fetch('/api/baskets/new', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      text_dump: args.text,
+      file_urls: args.files ?? [],
+      basket_name: args.name ?? null,
+    }),
+  });
+  if (res.status !== 201) {
+    const text = await res.text();
+    throw new Error(text || `createBasketNew failed with ${res.status}`);
+  }
+  const data = await res.json();
+  return { id: data.basket_id };
 }


### PR DESCRIPTION
## Summary
- unify FastAPI routers on main `app` and add `/` health check
- standardise basket-new router prefix
- update basket creation helper to expect HTTP 201

## Testing
- `uv run ruff check` *(fails: found 87 errors)*
- `PYTHONPATH=api/src uv run pytest -q` *(fails: ModuleNotFoundError: asyncpg)*
- `npm run build` *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68524a75ad588329b4160e047740de88