### PR TITLE
Update basket snapshot contract

### DIFF
--- a/api/src/app/routes/basket_snapshot.py
+++ b/api/src/app/routes/basket_snapshot.py
@@ -20,7 +20,7 @@ def get_basket_snapshot(basket_id: str) -> dict:
     try:
         dumps_resp = (
             supabase.table("raw_dumps")
-            .select("id,content,created_at")
+            .select("id,body_md,created_at")
             .eq("basket_id", basket_id)
             .order("created_at")
             .execute()
@@ -32,9 +32,9 @@ def get_basket_snapshot(basket_id: str) -> dict:
             .order("order")
             .execute()
         )
-    except Exception:
+    except Exception as err:
         logger.exception("get_basket_snapshot failed")
-        raise HTTPException(status_code=500, detail="internal error")
+        raise HTTPException(status_code=500, detail="internal error") from err
 
     raw_dumps = dumps_resp.data or []
     blocks = block_resp.data or []

--- a/api/src/app/util/snapshot_assembler.py
+++ b/api/src/app/util/snapshot_assembler.py
@@ -3,15 +3,36 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Any, Dict
+from typing import Any
 
 _ALLOWED_STATES = {"ACCEPTED", "LOCKED", "CONSTANT"}
 
 
 def assemble_snapshot(
-    raw_dumps: Iterable[Dict[str, Any]], blocks: Iterable[Dict[str, Any]]
-) -> Dict[str, Any]:
+    raw_dumps: Iterable[dict[str, Any]], blocks: Iterable[dict[str, Any]]
+) -> dict[str, Any]:
     """Return snapshot dict joining dumps and selected blocks."""
-    dumps = list(raw_dumps)
-    accepted_blocks = [b for b in blocks if b.get("state") in _ALLOWED_STATES]
-    return {"raw_dumps": dumps, "blocks": accepted_blocks}
+    dumps = sorted(raw_dumps, key=lambda d: d.get("created_at", ""))
+    latest_dump = dumps[-1]["body_md"] if dumps else ""
+
+    accepted_blocks: list[dict[str, Any]] = []
+    locked_blocks: list[dict[str, Any]] = []
+    constants: list[dict[str, Any]] = []
+
+    for b in blocks:
+        state = b.get("state")
+        if state not in _ALLOWED_STATES:
+            continue
+        if state == "ACCEPTED":
+            accepted_blocks.append(b)
+        elif state == "LOCKED":
+            locked_blocks.append(b)
+        elif state == "CONSTANT":
+            constants.append(b)
+
+    return {
+        "raw_dump": latest_dump,
+        "accepted_blocks": accepted_blocks,
+        "locked_blocks": locked_blocks,
+        "constants": constants,
+    }

--- a/api/tests/api/test_basket_snapshot.py
+++ b/api/tests/api/test_basket_snapshot.py
@@ -37,12 +37,18 @@ def test_snapshot_empty(monkeypatch):
     monkeypatch.setattr("app.routes.basket_snapshot.supabase", fake)
     res = client.get("/api/baskets/b1/snapshot")
     assert res.status_code == 200
-    assert res.json() == {"basket_id": "b1", "raw_dumps": [], "blocks": []}
+    assert res.json() == {
+        "basket_id": "b1",
+        "raw_dump": "",
+        "accepted_blocks": [],
+        "locked_blocks": [],
+        "constants": [],
+    }
 
 
 def test_snapshot_filters(monkeypatch):
     store = {
-        "raw_dumps": [{"id": "r1", "content": "d"}],
+        "raw_dumps": [{"id": "r1", "body_md": "d", "created_at": "t"}],
         "context_blocks": [
             {"id": "b1", "state": "ACCEPTED"},
             {"id": "b2", "state": "PROPOSED"},
@@ -55,5 +61,6 @@ def test_snapshot_filters(monkeypatch):
     assert res.status_code == 200
     body = res.json()
     assert body["basket_id"] == "b2"
-    assert body["raw_dumps"] == [{"id": "r1", "content": "d"}]
-    assert len(body["blocks"]) == 2
+    assert body["raw_dump"] == "d"
+    assert len(body["accepted_blocks"]) == 1
+    assert len(body["locked_blocks"]) == 1

--- a/api/tests/util/test_snapshot_assembler.py
+++ b/api/tests/util/test_snapshot_assembler.py
@@ -7,7 +7,8 @@ def test_assemble_filters_states():
         {"id": "2", "state": "PROPOSED"},
         {"id": "3", "state": "LOCKED"},
     ]
-    raw = ["a"]
+    raw = [{"body_md": "a", "created_at": "t"}]
     snap = assemble_snapshot(raw, blocks)
-    assert len(snap["blocks"]) == 2
-    assert snap["raw_dumps"] == ["a"]
+    assert len(snap["accepted_blocks"]) == 1
+    assert len(snap["locked_blocks"]) == 1
+    assert snap["raw_dump"] == "a"


### PR DESCRIPTION
## Summary
- return grouped blocks and raw dump in snapshot route
- adjust snapshot assembler to new output
- update snapshot tests

## Testing
- `uv run ruff check api/src/app/util/snapshot_assembler.py api/src/app/routes/basket_snapshot.py --quiet`
- `uv run pytest -q`
- `cd web && npm install && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68526a42ca108329a73c6f6e383bf8e8