### PR TITLE
Fix basket new contract drift

### DIFF
--- a/api/src/app/routes/basket_new.py
+++ b/api/src/app/routes/basket_new.py
@@ -11,7 +11,7 @@ router = APIRouter(prefix="/baskets", tags=["baskets"])
 
 
 class BasketCreatePayload(BaseModel):
-    text_dump: str = Field(..., alias="text", description="text_dump required")
+    text_dump: str = Field(..., alias="text_dump")
     file_urls: list[str] | None = None
     basket_name: str | None = None
 

--- a/api/tests/api/test_basket_new.py
+++ b/api/tests/api/test_basket_new.py
@@ -29,10 +29,23 @@ def test_basket_new(monkeypatch):
 
     resp = client.post(
         "/api/baskets/new",
-        json={"text": "hello", "file_urls": ["f"], "basket_name": "test"},
+        json={"text_dump": "hello", "file_urls": ["f"], "basket_name": "test"},
     )
     assert resp.status_code == 201
     body = resp.json()
     assert body["basket_id"]
+    assert len(store["baskets"]) == 1
+    assert len(store["raw_dumps"]) == 1
+
+
+def test_basket_new_minimal(monkeypatch):
+    store = {"baskets": [], "raw_dumps": []}
+    fake = types.SimpleNamespace(table=lambda n: _fake_table(n, store))
+    monkeypatch.setattr("app.routes.basket_new.supabase", fake)
+
+    resp = client.post("/api/baskets/new", json={"text_dump": "hello"})
+    assert resp.status_code == 201
+    body = resp.json()
+    assert len(body["basket_id"]) > 0
     assert len(store["baskets"]) == 1
     assert len(store["raw_dumps"]) == 1

--- a/docs/SCHEMA_SNAPSHOT.sql
+++ b/docs/SCHEMA_SNAPSHOT.sql
@@ -16,6 +16,9 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+-- Remove obsolete view used by early prototypes
+DROP VIEW IF EXISTS context_blocks;
+
 --
 -- Name: auth; Type: SCHEMA; Schema: -; Owner: -
 --

--- a/web/app/baskets/new/page.tsx
+++ b/web/app/baskets/new/page.tsx
@@ -16,7 +16,7 @@ export default function NewBasketPage() {
     if (!text.trim()) { alert("Please enter some text 😊"); return; }
     setSubmitting(true);
     try {
-      const { id } = await createBasketNew({ text_dump: text, files });
+      const { id } = await createBasketNew({ text_dump: text, file_urls: files });
       router.push(`/baskets/${id}/work`);
     } catch (err) {
       console.error(err);

--- a/web/lib/baskets/createBasketNew.ts
+++ b/web/lib/baskets/createBasketNew.ts
@@ -1,19 +1,16 @@
 export interface NewBasketArgs {
   text_dump: string;
-  files?: string[];
-  basket_name?: string | null;
+  file_urls?: string[];
 }
 export async function createBasketNew(
   args: NewBasketArgs,
 ): Promise<{ id: string }> {
-  const res = await fetch('/api/baskets/new', {
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL || '';
+  const payload = { text_dump: args.text_dump, file_urls: args.file_urls ?? [] };
+  const res = await fetch(`${base}/api/baskets/new`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      text_dump: args.text_dump,
-      file_urls: args.files ?? [],
-      basket_name: args.basket_name ?? null,
-    }),
+    body: JSON.stringify(payload),
   });
   if (res.status !== 201) {
     const text = await res.text();


### PR DESCRIPTION
## Summary
- rename `text` -> `text_dump` in BasketCreatePayload
- align front-end createBasketNew POST body and env URL
- handle new payload in baskets/new page
- document dropping obsolete `context_blocks` view
- update basket new tests

## Testing
- `npm --prefix web run build`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68526fd06da08329aa5bc87cf9f912f3