### PR TITLE
Fix basket_new to set raw_dump_id

### DIFF
--- a/api/src/app/routes/basket_new.py
+++ b/api/src/app/routes/basket_new.py
@@ -29,11 +29,20 @@ class BasketCreatePayload(BaseModel):
 async def create_basket(payload: BasketCreatePayload):
     logger.info("[basket_new] payload: %s", payload.model_dump())
     basket_id = str(uuid4())
+    raw_id = str(uuid4())
 
     try:
         resp = (
             supabase.table("baskets")
-            .insert(as_json({"id": basket_id, "name": payload.basket_name}))
+            .insert(
+                as_json(
+                    {
+                        "id": basket_id,
+                        "name": payload.basket_name,
+                        "raw_dump_id": raw_id,
+                    }
+                )
+            )
             .execute()
         )
     except Exception as err:
@@ -49,7 +58,7 @@ async def create_basket(payload: BasketCreatePayload):
             .insert(
                 as_json(
                     {
-                        "id": str(uuid4()),
+                        "id": raw_id,
                         "basket_id": basket_id,
                         "body_md": payload.text_dump,
                         "file_refs": payload.file_urls or [],

--- a/api/tests/api/test_new_snapshot_flow.py
+++ b/api/tests/api/test_new_snapshot_flow.py
@@ -1,0 +1,54 @@
+import os
+import types
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "svc.key")
+
+from app.routes.basket_new import router as new_router
+from app.routes.basket_snapshot import router as snapshot_router
+
+app = FastAPI()
+app.include_router(new_router, prefix="/api")
+app.include_router(snapshot_router, prefix="/api")
+client = TestClient(app)
+
+
+def _table(name, store):
+    def insert(row):
+        store[name].append(row)
+        return types.SimpleNamespace(
+            execute=lambda: types.SimpleNamespace(data=[row], error=None)
+        )
+
+    def select(*args, **kwargs):
+        class Q:
+            def eq(self, *a, **k):
+                return self
+
+            def order(self, *a, **k):
+                return self
+
+            def execute(self):
+                return types.SimpleNamespace(data=store.get(name, []))
+
+        return Q()
+
+    return types.SimpleNamespace(insert=insert, select=select)
+
+
+def test_snapshot_after_creation(monkeypatch):
+    store = {"baskets": [], "raw_dumps": [], "context_blocks": []}
+    fake = types.SimpleNamespace(table=lambda n: _table(n, store))
+    monkeypatch.setattr("app.routes.basket_new.supabase", fake)
+    monkeypatch.setattr("app.routes.basket_snapshot.supabase", fake)
+
+    resp = client.post("/api/baskets/new", json={"text_dump": "hello"})
+    assert resp.status_code == 201
+    basket_id = resp.json()["basket_id"]
+
+    snap = client.get(f"/api/baskets/{basket_id}/snapshot")
+    assert snap.status_code == 200
+    assert snap.json()["raw_dump"] == "hello"


### PR DESCRIPTION
## Summary
- include the raw dump foreign key when inserting a basket
- test snapshot route succeeds right after creating a basket

## Testing
- `make lint` *(fails: missing separator)*
- `make format` *(fails: missing separator)*
- `make tests` *(fails: missing separator)*
- `uv run ruff check` *(fails: F821 undefined names)*
- `uv run black .`
- `PYTHONPATH=api/src uv run pytest` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_68527dbd59788329bfa2dd63a87fc09e