### PR TITLE
Align basket creation & snapshot with Contract v1

### DIFF
--- a/api/src/app/routes/basket_new.py
+++ b/api/src/app/routes/basket_new.py
@@ -29,36 +29,15 @@ class BasketCreatePayload(BaseModel):
 async def create_basket(payload: BasketCreatePayload):
     logger.info("[basket_new] payload: %s", payload.model_dump())
     basket_id = str(uuid4())
-    raw_id = str(uuid4())
+    dump_id = str(uuid4())
 
     try:
-        resp = (
-            supabase.table("baskets")
-            .insert(
-                as_json(
-                    {
-                        "id": basket_id,
-                        "name": payload.basket_name,
-                        "raw_dump_id": raw_id,
-                    }
-                )
-            )
-            .execute()
-        )
-    except Exception as err:
-        logger.exception("basket insertion failed")
-        raise HTTPException(status_code=500, detail="internal error") from err
-    if resp.error:
-        logger.error("basket insertion error: %s", resp.error.message)
-        raise HTTPException(status_code=500, detail=resp.error.message)
-
-    try:
-        resp2 = (
+        resp_dump = (
             supabase.table("raw_dumps")
             .insert(
                 as_json(
                     {
-                        "id": raw_id,
+                        "id": dump_id,
                         "basket_id": basket_id,
                         "body_md": payload.text_dump,
                         "file_refs": payload.file_urls or [],
@@ -70,8 +49,29 @@ async def create_basket(payload: BasketCreatePayload):
     except Exception as err:
         logger.exception("raw_dumps insertion failed")
         raise HTTPException(status_code=500, detail="internal error") from err
-    if resp2.error:
-        logger.error("raw_dumps insertion error: %s", resp2.error.message)
-        raise HTTPException(status_code=500, detail=resp2.error.message)
+    if resp_dump.error:
+        logger.error("raw_dumps insertion error: %s", resp_dump.error.message)
+        raise HTTPException(status_code=500, detail=resp_dump.error.message)
+
+    try:
+        resp_basket = (
+            supabase.table("baskets")
+            .insert(
+                as_json(
+                    {
+                        "id": basket_id,
+                        "name": payload.basket_name,
+                        "raw_dump_id": dump_id,
+                    }
+                )
+            )
+            .execute()
+        )
+    except Exception as err:
+        logger.exception("basket insertion failed")
+        raise HTTPException(status_code=500, detail="internal error") from err
+    if resp_basket.error:
+        logger.error("basket insertion error: %s", resp_basket.error.message)
+        raise HTTPException(status_code=500, detail=resp_basket.error.message)
 
     return {"basket_id": basket_id}

--- a/api/src/app/routes/basket_snapshot.py
+++ b/api/src/app/routes/basket_snapshot.py
@@ -26,10 +26,11 @@ def get_basket_snapshot(basket_id: str) -> dict:
             .execute()
         )
         block_resp = (
-            supabase.table("context_blocks")
-            .select("id,type,content,state,order")
+            supabase.table("blocks")
+            .select(
+                "id,semantic_type,content,state,scope,canonical_value"
+            )
             .eq("basket_id", basket_id)
-            .order("order")
             .execute()
         )
     except Exception as err:
@@ -39,4 +40,4 @@ def get_basket_snapshot(basket_id: str) -> dict:
     raw_dumps = dumps_resp.data or []
     blocks = block_resp.data or []
     snapshot = assemble_snapshot(raw_dumps, blocks)
-    return {"basket_id": basket_id, **snapshot}
+    return snapshot

--- a/api/src/app/util/snapshot_assembler.py
+++ b/api/src/app/util/snapshot_assembler.py
@@ -5,34 +5,17 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any
 
-_ALLOWED_STATES = {"ACCEPTED", "LOCKED", "CONSTANT"}
-
-
 def assemble_snapshot(
     raw_dumps: Iterable[dict[str, Any]], blocks: Iterable[dict[str, Any]]
 ) -> dict[str, Any]:
     """Return snapshot dict joining dumps and selected blocks."""
     dumps = sorted(raw_dumps, key=lambda d: d.get("created_at", ""))
-    latest_dump = dumps[-1]["body_md"] if dumps else ""
+    latest = dumps[-1] if dumps else {"body_md": ""}
 
-    accepted_blocks: list[dict[str, Any]] = []
-    locked_blocks: list[dict[str, Any]] = []
-    constants: list[dict[str, Any]] = []
-
-    for b in blocks:
-        state = b.get("state")
-        if state not in _ALLOWED_STATES:
-            continue
-        if state == "ACCEPTED":
-            accepted_blocks.append(b)
-        elif state == "LOCKED":
-            locked_blocks.append(b)
-        elif state == "CONSTANT":
-            constants.append(b)
-
-    return {
-        "raw_dump": latest_dump,
-        "accepted_blocks": accepted_blocks,
-        "locked_blocks": locked_blocks,
-        "constants": constants,
+    grouped = {
+        "constants": [b for b in blocks if b.get("state") == "CONSTANT"],
+        "locked_blocks": [b for b in blocks if b.get("state") == "LOCKED"],
+        "accepted_blocks": [b for b in blocks if b.get("state") == "ACCEPTED"],
     }
+
+    return {"raw_dump": latest["body_md"], **grouped}

--- a/api/tests/api/test_basket_new.py
+++ b/api/tests/api/test_basket_new.py
@@ -16,6 +16,7 @@ client = TestClient(app)
 
 def _fake_table(name, store):
     def insert(row):
+        store["calls"].append(name)
         store[name].append(row)
         return types.SimpleNamespace(
             execute=lambda: types.SimpleNamespace(data=[row], error=None)
@@ -36,7 +37,7 @@ def _error_table(name):
 
 
 def test_basket_new(monkeypatch):
-    store = {"baskets": [], "raw_dumps": []}
+    store = {"baskets": [], "raw_dumps": [], "calls": []}
     fake = types.SimpleNamespace(table=lambda n: _fake_table(n, store))
     monkeypatch.setattr("app.routes.basket_new.supabase", fake)
 
@@ -49,10 +50,11 @@ def test_basket_new(monkeypatch):
     assert body["basket_id"]
     assert len(store["baskets"]) == 1
     assert len(store["raw_dumps"]) == 1
+    assert store["calls"] == ["raw_dumps", "baskets"]
 
 
 def test_basket_new_minimal(monkeypatch):
-    store = {"baskets": [], "raw_dumps": []}
+    store = {"baskets": [], "raw_dumps": [], "calls": []}
     fake = types.SimpleNamespace(table=lambda n: _fake_table(n, store))
     monkeypatch.setattr("app.routes.basket_new.supabase", fake)
 
@@ -62,6 +64,7 @@ def test_basket_new_minimal(monkeypatch):
     assert len(body["basket_id"]) > 0
     assert len(store["baskets"]) == 1
     assert len(store["raw_dumps"]) == 1
+    assert store["calls"] == ["raw_dumps", "baskets"]
 
 
 def test_basket_new_error(monkeypatch):

--- a/api/tests/api/test_basket_snapshot.py
+++ b/api/tests/api/test_basket_snapshot.py
@@ -32,13 +32,12 @@ def _fake_table(name, store):
 
 
 def test_snapshot_empty(monkeypatch):
-    store = {"raw_dumps": [], "context_blocks": []}
+    store = {"raw_dumps": [], "blocks": []}
     fake = types.SimpleNamespace(table=lambda n: _fake_table(n, store))
     monkeypatch.setattr("app.routes.basket_snapshot.supabase", fake)
     res = client.get("/api/baskets/b1/snapshot")
     assert res.status_code == 200
     assert res.json() == {
-        "basket_id": "b1",
         "raw_dump": "",
         "accepted_blocks": [],
         "locked_blocks": [],
@@ -49,7 +48,7 @@ def test_snapshot_empty(monkeypatch):
 def test_snapshot_filters(monkeypatch):
     store = {
         "raw_dumps": [{"id": "r1", "body_md": "d", "created_at": "t"}],
-        "context_blocks": [
+        "blocks": [
             {"id": "b1", "state": "ACCEPTED"},
             {"id": "b2", "state": "PROPOSED"},
             {"id": "b3", "state": "LOCKED"},
@@ -60,7 +59,6 @@ def test_snapshot_filters(monkeypatch):
     res = client.get("/api/baskets/b2/snapshot")
     assert res.status_code == 200
     body = res.json()
-    assert body["basket_id"] == "b2"
     assert body["raw_dump"] == "d"
     assert len(body["accepted_blocks"]) == 1
     assert len(body["locked_blocks"]) == 1

--- a/api/tests/api/test_new_snapshot_flow.py
+++ b/api/tests/api/test_new_snapshot_flow.py
@@ -40,7 +40,7 @@ def _table(name, store):
 
 
 def test_snapshot_after_creation(monkeypatch):
-    store = {"baskets": [], "raw_dumps": [], "context_blocks": []}
+    store = {"baskets": [], "raw_dumps": [], "blocks": []}
     fake = types.SimpleNamespace(table=lambda n: _table(n, store))
     monkeypatch.setattr("app.routes.basket_new.supabase", fake)
     monkeypatch.setattr("app.routes.basket_snapshot.supabase", fake)

--- a/api/tests/util/test_snapshot_assembler.py
+++ b/api/tests/util/test_snapshot_assembler.py
@@ -6,9 +6,11 @@ def test_assemble_filters_states():
         {"id": "1", "state": "ACCEPTED"},
         {"id": "2", "state": "PROPOSED"},
         {"id": "3", "state": "LOCKED"},
+        {"id": "4", "state": "CONSTANT"},
     ]
     raw = [{"body_md": "a", "created_at": "t"}]
     snap = assemble_snapshot(raw, blocks)
     assert len(snap["accepted_blocks"]) == 1
     assert len(snap["locked_blocks"]) == 1
+    assert len(snap["constants"]) == 1
     assert snap["raw_dump"] == "a"

--- a/web/lib/baskets/getSnapshot.ts
+++ b/web/lib/baskets/getSnapshot.ts
@@ -3,11 +3,13 @@ import { apiGet } from '@/lib/api';
 export interface Block {
   id: string;
   content?: string;
+  semantic_type?: string;
   state: string;
+  scope?: string;
+  canonical_value?: string;
 }
 
 export interface Snapshot {
-  basket_id: string;
   raw_dump: string;
   accepted_blocks: Block[];
   locked_blocks: Block[];


### PR DESCRIPTION
## Summary
- insert raw dumps before baskets in `/api/baskets/new`
- read snapshot data from `blocks` table
- group snapshot blocks by state in `snapshot_assembler`
- adapt backend tests for new snapshot and insert order
- tweak web snapshot type

## Testing
- `PYTHONPATH=api/src uv run pytest`
- `npm --prefix web run build`

------
https://chatgpt.com/codex/tasks/task_e_68534dfff244832990da205aa2e8b9a9