### PR TITLE
Fix Blockifier pipeline for Contract v1

### DIFF
--- a/api/src/app/agent_tasks/orch/orch_block_manager_agent.py
+++ b/api/src/app/agent_tasks/orch/orch_block_manager_agent.py
@@ -8,39 +8,57 @@ from app.utils.supabase_client import supabase_client as supabase
 def run(basket_id: UUID) -> dict:
     """Insert a placeholder block then record a revision and event."""
     block_id = str(uuid4())
-    supabase.table("blocks").insert(
-        json_safe(
-            {
-                "id": block_id,
-                "basket_id": str(basket_id),
-                "type": "placeholder",
-                "content": "pending proposal",
-                "state": "PROPOSED",
-            }
+    res = (
+        supabase.table("blocks")
+        .insert(
+            json_safe(
+                {
+                    "id": block_id,
+                    "basket_id": str(basket_id),
+                    "semantic_type": "placeholder",
+                    "content": "pending proposal",
+                    "state": "PROPOSED",
+                }
+            )
         )
-    ).execute()
+        .execute()
+    )
+    if res.error:  # type: ignore[attr-defined]
+        raise RuntimeError(res.error.message)
 
-    supabase.table("block_revisions").insert(
-        json_safe(
-            {
-                "block_id": block_id,
-                "prev_content": None,
-                "new_content": "pending proposal",
-                "changed_by": "orch_block_manager_agent",
-                "proposal_event": {},
-            }
+    res = (
+        supabase.table("block_revisions")
+        .insert(
+            json_safe(
+                {
+                    "block_id": block_id,
+                    "prev_content": None,
+                    "new_content": "pending proposal",
+                    "changed_by": "orch_block_manager_agent",
+                    "proposal_event": {},
+                }
+            )
         )
-    ).execute()
+        .execute()
+    )
+    if res.error:  # type: ignore[attr-defined]
+        raise RuntimeError(res.error.message)
 
-    supabase.table("events").insert(
-        json_safe(
-            {
-                "basket_id": str(basket_id),
-                "block_id": block_id,
-                "kind": "orch_block_manager.proposed",
-                "payload": {},
-            }
+    res = (
+        supabase.table("events")
+        .insert(
+            json_safe(
+                {
+                    "basket_id": str(basket_id),
+                    "block_id": block_id,
+                    "kind": "orch_block_manager.proposed",
+                    "payload": {},
+                }
+            )
         )
-    ).execute()
+        .execute()
+    )
+    if res.error:  # type: ignore[attr-defined]
+        raise RuntimeError(res.error.message)
 
-    return {"block_id": block_id}
+    return {"proposed": 1}

--- a/api/src/app/routes/agents.py
+++ b/api/src/app/routes/agents.py
@@ -5,20 +5,30 @@ from pydantic import BaseModel
 
 from ..agent_tasks.orch.orch_block_manager_agent import run as run_orch_block_manager
 from ..agent_tasks.infra.infra_cil_validator_agent import run as run_infra_cil_validator
+from ..utils.supabase_client import supabase_client as supabase
 
 router = APIRouter(prefix="/agents", tags=["agents"])
 
 
-class RunPayload(BaseModel):
+class AgentRunPayload(BaseModel):
     basket_id: UUID
 
 
 @router.post("/{name}/run")
-def run_agent(name: str, payload: RunPayload):
+def run_agent(name: str, payload: AgentRunPayload):
+    res = (
+        supabase.table("baskets")
+        .select("id")
+        .eq("id", str(payload.basket_id))
+        .execute()
+    )
+    if not res.data:  # type: ignore[attr-defined]
+        raise HTTPException(status_code=404, detail="basket not found")
+
     if name == "orch_block_manager":
-        run_orch_block_manager(payload.basket_id)
+        result = run_orch_block_manager(payload.basket_id)
     elif name == "infra_cil_validator":
-        run_infra_cil_validator(payload.basket_id)
+        result = run_infra_cil_validator(payload.basket_id)
     else:
         raise HTTPException(status_code=404, detail="unknown agent")
-    return {"status": "ok"}
+    return result

--- a/api/tests/api/test_orch_block_manager.py
+++ b/api/tests/api/test_orch_block_manager.py
@@ -1,0 +1,57 @@
+import types
+import uuid
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import sys
+import os
+
+asyncpg_stub = types.SimpleNamespace(Connection=object)
+sys.modules.setdefault("asyncpg", asyncpg_stub)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))
+
+from app.routes.agents import router as agents_router
+
+app = FastAPI()
+app.include_router(agents_router, prefix="/api")
+client = TestClient(app)
+
+
+def _fake_supabase(store):
+    def table(name: str):
+        def insert(row: dict):
+            row = {**row}
+            if "id" not in row:
+                row["id"] = str(uuid.uuid4())
+            store.setdefault(name, []).append(row)
+            return types.SimpleNamespace(execute=lambda: types.SimpleNamespace(data=[row], error=None))
+
+        def select(_cols="*"):
+            def eq(col: str, val: str):
+                items = [r for r in store.get(name, []) if r.get(col) == val]
+                return types.SimpleNamespace(execute=lambda: types.SimpleNamespace(data=items, error=None))
+
+            return types.SimpleNamespace(eq=eq)
+
+        return types.SimpleNamespace(insert=insert, select=select)
+
+    return types.SimpleNamespace(table=table)
+
+
+def test_run_blockifier(monkeypatch):
+    store = {"baskets": [], "raw_dumps": [], "blocks": []}
+    fake = _fake_supabase(store)
+    monkeypatch.setattr("app.routes.agents.supabase", fake)
+    monkeypatch.setattr("app.agent_tasks.orch.orch_block_manager_agent.supabase", fake)
+
+    basket_id = str(uuid.uuid4())
+    dump_id = str(uuid.uuid4())
+    store["baskets"].append({"id": basket_id, "raw_dump_id": dump_id})
+    store["raw_dumps"].append({"id": dump_id, "basket_id": basket_id, "body_md": "d"})
+
+    resp = client.post("/api/agents/orch_block_manager/run", json={"basket_id": basket_id})
+    assert resp.status_code == 200
+    assert resp.json()["proposed"] >= 1
+    assert store["blocks"]
+

--- a/supabase/migrations/20250621010000_rename_type_column.sql
+++ b/supabase/migrations/20250621010000_rename_type_column.sql
@@ -1,0 +1,2 @@
+-- Rename old column if present
+ALTER TABLE blocks RENAME COLUMN type TO semantic_type;

--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -5,6 +5,7 @@ import useSWR from "swr";
 import { apiPost, apiGet } from "@/lib/api";
 import type { Snapshot } from "@/lib/baskets/getSnapshot";
 import { Button } from "@/components/ui/Button";
+import { toast } from "react-hot-toast";
 
 export default function BasketWorkPage({ params }: any) {
   const id = params.id as string;
@@ -14,8 +15,13 @@ export default function BasketWorkPage({ params }: any) {
   );
 
   const runBlockifier = async () => {
-    await apiPost(`/api/agents/orch_block_manager/run`, { basket_id: id });
-    mutate();
+    try {
+      await apiPost(`/api/agents/orch_block_manager/run`, { basket_id: id });
+      toast.success("Parsing complete");
+      mutate();
+    } catch (err) {
+      toast.error("Failed to run Blockifier");
+    }
   };
 
   if (isLoading) return <div className="p-6">Loading…</div>;
@@ -27,6 +33,7 @@ export default function BasketWorkPage({ params }: any) {
     CONSTANT: data?.constants ?? [],
     LOCKED: data?.locked_blocks ?? [],
     ACCEPTED: data?.accepted_blocks ?? [],
+    PROPOSED: data?.proposed_blocks ?? [],
   };
 
   return (
@@ -43,11 +50,21 @@ export default function BasketWorkPage({ params }: any) {
       </section>
 
       {(
-        Object.entries(grouped) as ["CONSTANT" | "LOCKED" | "ACCEPTED", any[]][]
+        Object.entries(grouped) as [
+          "CONSTANT" | "LOCKED" | "ACCEPTED" | "PROPOSED",
+          any[],
+        ][]
       ).map(([state, arr]) => (
         <section key={state}>
           <h3 className="font-semibold text-lg">
-            {state === "CONSTANT" ? "★" : state === "LOCKED" ? "🔒" : "■"} {state}
+            {state === "CONSTANT"
+              ? "★"
+              : state === "LOCKED"
+              ? "🔒"
+              : state === "ACCEPTED"
+              ? "■"
+              : "□"}{" "}
+            {state}
           </h3>
           <ul className="list-disc pl-5 text-sm space-y-1">
             {arr.map((b) => (

--- a/web/lib/baskets/getSnapshot.ts
+++ b/web/lib/baskets/getSnapshot.ts
@@ -14,6 +14,7 @@ export interface Snapshot {
   accepted_blocks: Block[];
   locked_blocks: Block[];
   constants: Block[];
+  proposed_blocks: Block[];
 }
 
 export async function getSnapshot(basketId: string): Promise<Snapshot> {

--- a/web/tests/e2e/run_blockifier.spec.ts
+++ b/web/tests/e2e/run_blockifier.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+// Simulated snapshot responses before and after running Blockifier
+const firstSnapshot = {
+  raw_dump: '# dump',
+  accepted_blocks: [],
+  locked_blocks: [],
+  constants: [],
+  proposed_blocks: [],
+};
+const secondSnapshot = {
+  ...firstSnapshot,
+  proposed_blocks: [
+    { id: 'p1', content: 'hello', state: 'PROPOSED', semantic_type: 'note' },
+  ],
+};
+
+test('run blockifier flow', async ({ page }) => {
+  let snapCall = 0;
+  await page.route('**/api/baskets/test-basket/snapshot', async (route) => {
+    snapCall += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(snapCall === 1 ? firstSnapshot : secondSnapshot),
+    });
+  });
+
+  await page.route('**/api/agents/orch_block_manager/run', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ proposed: 1 }),
+    });
+  });
+
+  await page.goto('/baskets/test-basket/work');
+  await page.getByRole('button', { name: 'Run Blockifier' }).click();
+
+  await expect(page.getByText('Parsing complete')).toBeVisible();
+  await expect(page.getByRole('heading', { name: '□ PROPOSED' })).toBeVisible();
+});
+


### PR DESCRIPTION
## Summary
- rename legacy `type` column via migration
- handle `semantic_type` and `state` in orch_block_manager_agent
- validate basket exists before running agents
- show PROPOSED blocks on basket work page
- add backend and e2e tests for running Blockifier

## Testing
- `uv run pytest -q`
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_68537bacdb3083298a5b135986d45228