### PR TITLE
Make blocks rename migration idempotent

### DIFF
--- a/supabase/migrations/20250621010000_rename_type_column.sql
+++ b/supabase/migrations/20250621010000_rename_type_column.sql
@@ -1,2 +1,12 @@
 -- Rename old column if present
-ALTER TABLE blocks RENAME COLUMN type TO semantic_type;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'blocks'
+      AND column_name = 'type'
+  ) THEN
+    ALTER TABLE blocks RENAME COLUMN type TO semantic_type;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- make the type -> semantic_type migration idempotent

## Testing
- `pnpm lint && pnpm test`
- `make lint` *(fails: missing separator)*
- `make format` *(fails: missing separator)*
- `make tests` *(fails: missing separator)*
- `npx supabase gen types typescript --local` *(fails: Docker not running)*

------
https://chatgpt.com/codex/tasks/task_e_68538e0773a88329b6de989ff0a1463d