### PR TITLE
Refactor settings UI, remove sidebar link

### DIFF
--- a/web/app/components/layout/Sidebar.tsx
+++ b/web/app/components/layout/Sidebar.tsx
@@ -34,9 +34,6 @@ const Sidebar = ({ open, onClose }: SidebarProps) => {
     router.push("/");
   };
 
-  const handleSettings = () => {
-    router.push("/settings");
-  };
 
   return (
     <aside
@@ -81,7 +78,6 @@ const Sidebar = ({ open, onClose }: SidebarProps) => {
                 seulkim88@gmail.com
               </summary>
               <div className="mt-2 ml-2 flex flex-col space-y-1 text-sm text-muted-foreground">
-                <button onClick={handleSettings}>⚙️ Settings</button>
                 <button onClick={handleLogout}>🔓 Sign Out</button>
               </div>
             </details>

--- a/web/components/settings/PreferencesTab.tsx
+++ b/web/components/settings/PreferencesTab.tsx
@@ -3,24 +3,45 @@
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { fetchMockPreferences, saveMockPreferences, Preferences } from "@/lib/mocks/settings";
+import {
+  fetchMockPreferences,
+  saveMockPreferences,
+  Preferences,
+} from "@/lib/mocks/settings";
 import toast from "react-hot-toast";
 
 export default function PreferencesTab() {
   const [prefs, setPrefs] = useState<Preferences | null>(null);
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetchMockPreferences().then(setPrefs);
+    async function load() {
+      try {
+        const data = await fetchMockPreferences();
+        setPrefs(data);
+      } catch (err) {
+        console.error("Failed to load preferences", err);
+        setError("Failed to load preferences");
+      }
+    }
+    load();
   }, []);
 
+  if (error) return <div>{error}</div>;
   if (!prefs) return <div>Loading...</div>;
 
   const handleSave = async () => {
     setSaving(true);
-    await saveMockPreferences(prefs);
-    setSaving(false);
-    toast.success("Saved (mock)");
+    try {
+      await saveMockPreferences(prefs);
+      toast.success("Saved (mock)");
+    } catch (err) {
+      console.error("Failed to save preferences", err);
+      toast.error("Failed to save");
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (

--- a/web/components/settings/ProfileTab.tsx
+++ b/web/components/settings/ProfileTab.tsx
@@ -2,94 +2,46 @@
 
 import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/Input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Button } from "@/components/ui/Button";
-import { fetchMockProfile, saveMockProfile, Profile } from "@/lib/mocks/settings";
-import moment from "moment-timezone";
-import toast from "react-hot-toast";
+import { createClient } from "@/lib/supabaseClient";
+import type { User } from "@supabase/supabase-js";
 
 export default function ProfileTab() {
-  const [profile, setProfile] = useState<Profile | null>(null);
+  const supabase = createClient();
+  const [user, setUser] = useState<User | null>(null);
+
   useEffect(() => {
-    fetchMockProfile().then(setProfile);
-  }, []);
+    async function load() {
+      const { data, error } = await supabase.auth.getUser();
+      if (error) {
+        console.error("Error fetching user", error);
+        return;
+      }
+      setUser(data.user);
+    }
+    load();
+  }, [supabase]);
 
-  const [saving, setSaving] = useState(false);
+  if (!user) return <div>Loading...</div>;
 
-  if (!profile) return <div>Loading...</div>;
-
-  const locales = ["en-US", "fr-FR", "es-ES"];
-  const timezones = moment.tz.names();
-
-  const handleSave = async () => {
-    setSaving(true);
-    await saveMockProfile(profile);
-    setSaving(false);
-    toast.success("Saved (mock)");
-  };
+  const displayName =
+    (user.user_metadata?.full_name as string) ||
+    (user.user_metadata?.name as string) ||
+    "";
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center space-x-4">
-        {/* TODO(api): replace with real avatar uploader */}
-        <img src={profile.avatarUrl} alt="avatar" className="h-16 w-16 rounded-full object-cover" />
-        <input
-          type="file"
-          onChange={(e) => {
-            const file = e.target.files?.[0];
-            if (file) {
-              const url = URL.createObjectURL(file);
-              setProfile({ ...profile, avatarUrl: url });
-            }
-          }}
-        />
+      <div className="space-y-2">
+        <label className="text-sm font-medium">UID</label>
+        <Input value={user.id} readOnly />
       </div>
       <div className="space-y-2">
         <label className="text-sm font-medium">Display Name</label>
-        <Input
-          value={profile.displayName}
-          onChange={(e) => setProfile({ ...profile, displayName: e.target.value })}
-        />
+        <Input value={displayName} readOnly />
       </div>
       <div className="space-y-2">
-        <label className="text-sm font-medium">Locale</label>
-        <Select
-          value={profile.locale}
-          onValueChange={(value) => setProfile({ ...profile, locale: value })}
-        >
-          <SelectTrigger>
-            <SelectValue placeholder="Select locale" />
-          </SelectTrigger>
-          <SelectContent className="max-h-48 overflow-y-auto">
-            {locales.map((loc) => (
-              <SelectItem key={loc} value={loc}>
-                {loc}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <label className="text-sm font-medium">Email</label>
+        <Input value={user.email ?? ""} readOnly />
       </div>
-      <div className="space-y-2">
-        <label className="text-sm font-medium">Timezone</label>
-        <Select
-          value={profile.timezone}
-          onValueChange={(value) => setProfile({ ...profile, timezone: value })}
-        >
-          <SelectTrigger>
-            <SelectValue placeholder="Select timezone" />
-          </SelectTrigger>
-          <SelectContent className="max-h-48 overflow-y-auto">
-            {timezones.map((tz) => (
-              <SelectItem key={tz} value={tz}>
-                {tz}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-      <Button onClick={handleSave} disabled={saving}>
-        Save
-      </Button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- improve Preferences tab error handling
- show Supabase user info on Profile tab (read-only)
- remove duplicate settings link from Sidebar

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Command "typecheck" not found)*
- `pnpm test --filter settings`

------
https://chatgpt.com/codex/tasks/task_e_6853930979408329a912d5352f6869b5