### PR TITLE
Refactor orch_block_manager for new PostgREST style

### DIFF
--- a/api/src/app/agent_tasks/layer3_config/agents/config_agent.py
+++ b/api/src/app/agent_tasks/layer3_config/agents/config_agent.py
@@ -21,7 +21,7 @@ async def generate(payload: ConfigIn) -> ConfigOut:
             brief_id,
         )
         blocks = await conn.fetch(
-            "select cb.type, cb.content "
+            "select cb.semantic_type, cb.content "
             "from block_brief_link bl join blocks cb on cb.id=bl.block_id "
             "where bl.task_brief_id=$1",
             brief_id,

--- a/api/src/app/agent_tasks/orch/orch_block_manager_agent.py
+++ b/api/src/app/agent_tasks/orch/orch_block_manager_agent.py
@@ -23,8 +23,8 @@ def run(basket_id: UUID) -> dict:
         )
         .execute()
     )
-    if res.error:  # type: ignore[attr-defined]
-        raise RuntimeError(res.error.message)
+    if getattr(res, "status_code", 200) >= 300 or getattr(res, "error", None):
+        raise RuntimeError(str(getattr(res, "error", res)))
 
     res = (
         supabase.table("block_revisions")
@@ -41,8 +41,8 @@ def run(basket_id: UUID) -> dict:
         )
         .execute()
     )
-    if res.error:  # type: ignore[attr-defined]
-        raise RuntimeError(res.error.message)
+    if getattr(res, "status_code", 200) >= 300 or getattr(res, "error", None):
+        raise RuntimeError(str(getattr(res, "error", res)))
 
     res = (
         supabase.table("events")
@@ -58,7 +58,7 @@ def run(basket_id: UUID) -> dict:
         )
         .execute()
     )
-    if res.error:  # type: ignore[attr-defined]
-        raise RuntimeError(res.error.message)
+    if getattr(res, "status_code", 200) >= 300 or getattr(res, "error", None):
+        raise RuntimeError(str(getattr(res, "error", res)))
 
     return {"proposed": 1}

--- a/api/src/app/routes/agents.py
+++ b/api/src/app/routes/agents.py
@@ -1,10 +1,11 @@
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException
+from postgrest.exceptions import APIError
 from pydantic import BaseModel
 
-from ..agent_tasks.orch.orch_block_manager_agent import run as run_orch_block_manager
 from ..agent_tasks.infra.infra_cil_validator_agent import run as run_infra_cil_validator
+from ..agent_tasks.orch.orch_block_manager_agent import run as run_orch_block_manager
 from ..utils.supabase_client import supabase_client as supabase
 
 router = APIRouter(prefix="/agents", tags=["agents"])
@@ -25,10 +26,13 @@ def run_agent(name: str, payload: AgentRunPayload):
     if not res.data:  # type: ignore[attr-defined]
         raise HTTPException(status_code=404, detail="basket not found")
 
-    if name == "orch_block_manager":
-        result = run_orch_block_manager(payload.basket_id)
-    elif name == "infra_cil_validator":
-        result = run_infra_cil_validator(payload.basket_id)
-    else:
-        raise HTTPException(status_code=404, detail="unknown agent")
+    try:
+        if name == "orch_block_manager":
+            result = run_orch_block_manager(payload.basket_id)
+        elif name == "infra_cil_validator":
+            result = run_infra_cil_validator(payload.basket_id)
+        else:
+            raise HTTPException(status_code=404, detail="unknown agent")
+    except APIError as err:
+        raise HTTPException(status_code=500, detail=str(err)) from err
     return result

--- a/api/src/app/routes/baskets.py
+++ b/api/src/app/routes/baskets.py
@@ -53,8 +53,9 @@ async def create_basket(payload: BasketCreate):
     except Exception as err:
         logger.exception("create_basket failed")
         raise HTTPException(status_code=500, detail="internal error") from err
-    if resp.error:
-        raise HTTPException(status_code=500, detail=resp.error.message)
+    if getattr(resp, "status_code", 200) >= 400 or getattr(resp, "error", None):
+        detail = getattr(resp, "error", resp)
+        raise HTTPException(status_code=500, detail=str(detail))
 
     blocks: list[dict[str, Any]] = [
         {

--- a/api/src/app/routes/dump_new.py
+++ b/api/src/app/routes/dump_new.py
@@ -34,8 +34,10 @@ async def create_dump(p: DumpPayload):
         )
         .execute()
     )
-    if resp.error:
-        raise HTTPException(500, resp.error.message)
+    if getattr(resp, "status_code", 200) >= 400 or getattr(resp, "error", None):
+        err = getattr(resp, "error", None)
+        detail = err.message if getattr(err, "message", None) else str(err or resp)
+        raise HTTPException(500, detail)
 
     supabase.table("events").insert(
         as_json(

--- a/tests/api/agents/test_orch_block_manager.py
+++ b/tests/api/agents/test_orch_block_manager.py
@@ -1,0 +1,42 @@
+import importlib
+from pathlib import Path
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tests.agent_tasks.test_agent_scaffold import _setup_supabase
+
+
+def test_run_agent_inserts_block(monkeypatch):
+    records = _setup_supabase(monkeypatch)
+    base = Path(__file__).resolve().parents[3]
+
+    # Load agent and router modules after patching Supabase
+    spec = importlib.util.spec_from_file_location(
+        "app.routes.agents", base / "api" / "src" / "app" / "routes" / "agents.py"
+    )
+    router_mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(router_mod)
+
+    orch_spec = importlib.util.spec_from_file_location(
+        "app.agent_tasks.orch.orch_block_manager_agent",
+        base / "api" / "src" / "app" / "agent_tasks" / "orch" / "orch_block_manager_agent.py",
+    )
+    orch_mod = importlib.util.module_from_spec(orch_spec)
+    assert orch_spec and orch_spec.loader
+    orch_spec.loader.exec_module(orch_mod)
+
+    app = FastAPI()
+    app.include_router(router_mod.router, prefix="/api")
+    client = TestClient(app)
+
+    basket_id = str(uuid4())
+    dump_id = str(uuid4())
+    records["baskets"] = [{"id": basket_id, "raw_dump_id": dump_id}]
+    records["raw_dumps"] = [{"id": dump_id, "basket_id": basket_id, "body_md": "d"}]
+
+    resp = client.post("/api/agents/orch_block_manager/run", json={"basket_id": basket_id})
+    assert resp.status_code == 200
+    assert records["blocks"][0]["state"] == "PROPOSED"


### PR DESCRIPTION
## Summary
- update orch_block_manager_agent to use new column names and status_code checks
- update config_agent SQL for semantic_type
- regenerate Supabase TypeScript types
- use status_code handling in API routes
- add integration test for orch_block_manager

## Testing
- `pre-commit run --files api/src/app/agent_tasks/layer3_config/agents/config_agent.py api/src/app/agent_tasks/orch/orch_block_manager_agent.py api/src/app/routes/agents.py api/src/app/routes/baskets.py api/src/app/routes/dump_new.py api/src/app/routes/task_brief.py tests/api/agents/test_orch_block_manager.py`
- `pytest -q` *(fails: assert 'fk fail' in response and agent run 500)*

------
https://chatgpt.com/codex/tasks/task_e_685396c038988329b15d00533608cf35