### PR TITLE
Hot-fix baskets embed & Blockifier agent crash

### DIFF
--- a/api/src/app/agent_tasks/orch/orch_block_manager_agent.py
+++ b/api/src/app/agent_tasks/orch/orch_block_manager_agent.py
@@ -1,3 +1,4 @@
+from typing import Any
 from uuid import UUID, uuid4
 
 from src.utils.db import json_safe
@@ -5,7 +6,7 @@ from src.utils.db import json_safe
 from app.utils.supabase_client import supabase_client as supabase
 
 
-def run(basket_id: UUID) -> dict:
+def run(basket_id: UUID) -> dict[str, Any]:
     """Insert a placeholder block then record a revision and event."""
     block_id = str(uuid4())
     res = (
@@ -23,8 +24,8 @@ def run(basket_id: UUID) -> dict:
         )
         .execute()
     )
-    if getattr(res, "status_code", 200) >= 300 or getattr(res, "error", None):
-        raise RuntimeError(str(getattr(res, "error", res)))
+    if res.status_code >= 400:
+        raise RuntimeError(f"Supabase error: {res.json()}")
 
     res = (
         supabase.table("block_revisions")
@@ -41,8 +42,8 @@ def run(basket_id: UUID) -> dict:
         )
         .execute()
     )
-    if getattr(res, "status_code", 200) >= 300 or getattr(res, "error", None):
-        raise RuntimeError(str(getattr(res, "error", res)))
+    if res.status_code >= 400:
+        raise RuntimeError(f"Supabase error: {res.json()}")
 
     res = (
         supabase.table("events")
@@ -58,7 +59,6 @@ def run(basket_id: UUID) -> dict:
         )
         .execute()
     )
-    if getattr(res, "status_code", 200) >= 300 or getattr(res, "error", None):
-        raise RuntimeError(str(getattr(res, "error", res)))
-
-    return {"proposed": 1}
+    if res.status_code >= 400:
+        raise RuntimeError(f"Supabase error: {res.json()}")
+    return {"inserted": len(res.data)}

--- a/tests/agent_tasks/test_agent_scaffold.py
+++ b/tests/agent_tasks/test_agent_scaffold.py
@@ -10,11 +10,21 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 
+class StubResponse:
+    def __init__(self, data, status_code=200):
+        self.data = data
+        self.status_code = status_code
+
+    def json(self):  # pragma: no cover - simple stub
+        return {"data": self.data}
+
+
 class StubTable:
     def __init__(self, records, name):
         self.records = records
         self.name = name
         self.filters = {}
+        self.status_code = 200
 
     def insert(self, data):
         self.records.setdefault(self.name, []).append(data)
@@ -32,7 +42,7 @@ class StubTable:
         rows = self.records.get(self.name, [])
         for col, val in self.filters.items():
             rows = [r for r in rows if r.get(col) == val]
-        return type("Resp", (), {"data": rows, "error": None})()
+        return StubResponse(rows, self.status_code)
 
 
 class StubClient:

--- a/tests/agent_tasks/test_orch_block_manager_agent.py
+++ b/tests/agent_tasks/test_orch_block_manager_agent.py
@@ -2,6 +2,7 @@ import importlib
 from pathlib import Path
 from uuid import uuid4
 
+import pytest
 from tests.agent_tasks.test_agent_scaffold import _setup_supabase
 
 
@@ -28,4 +29,45 @@ def test_run_proposes_block(monkeypatch):
 
     module.run(basket_id)
     assert records["blocks"][0]["state"] == "PROPOSED"
+
+
+def test_run_raises_on_error(monkeypatch):
+    records = _setup_supabase(monkeypatch)
+    basket_id = uuid4()
+
+    spec = importlib.util.spec_from_file_location(
+        "orch_block_manager_agent",
+        Path(__file__).resolve().parents[2]
+        / "api"
+        / "src"
+        / "app"
+        / "agent_tasks"
+        / "orch"
+        / "orch_block_manager_agent.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+
+    def bad_table(name: str):
+        class Bad:
+            def insert(self, data):
+                return self
+
+            def execute(self):
+                return type(
+                    "Resp",
+                    (),
+                    {
+                        "data": [],
+                        "status_code": 400,
+                        "json": lambda self: {"error": "bad"},
+                    },
+                )()
+
+        return Bad()
+
+    monkeypatch.setattr(module, "supabase", type("S", (), {"table": bad_table}))
+    with pytest.raises(RuntimeError):
+        module.run(basket_id)
 

--- a/tests/api/agents/test_orch_block_manager.py
+++ b/tests/api/agents/test_orch_block_manager.py
@@ -1,15 +1,27 @@
 import importlib
 from pathlib import Path
 from uuid import uuid4
+import types
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
+asyncpg_stub = types.SimpleNamespace(Connection=object)
+sys.modules.setdefault("asyncpg", asyncpg_stub)
 
 from tests.agent_tasks.test_agent_scaffold import _setup_supabase
 
 
 def test_run_agent_inserts_block(monkeypatch):
     records = _setup_supabase(monkeypatch)
+    for mod in ["app.routes.agents", "app.agent_tasks.orch.orch_block_manager_agent"]:
+        if mod in sys.modules:
+            del sys.modules[mod]
     base = Path(__file__).resolve().parents[3]
 
     # Load agent and router modules after patching Supabase

--- a/tests/contracts/test_event_log.py
+++ b/tests/contracts/test_event_log.py
@@ -7,8 +7,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../api/src"))
 import pytest
 
 
-@pytest.mark.asyncio
-async def test_log_insert(monkeypatch):
+def test_log_insert(monkeypatch):
     records = {}
 
     class StubTable:
@@ -30,6 +29,7 @@ async def test_log_insert(monkeypatch):
         del sys.modules["app.utils.supabase_client"]
     event_log = importlib.import_module("utils.event_log")
 
-    await event_log.log_event(basket_id="b", agent="a", phase="start", payload={})
+    import asyncio
+    asyncio.run(event_log.log_event(basket_id="b", agent="a", phase="start", payload={}))
     assert records["agent"] == "a"
     assert records["phase"] == "start"

--- a/web/lib/baskets/getAllBaskets.ts
+++ b/web/lib/baskets/getAllBaskets.ts
@@ -17,14 +17,21 @@ export async function getAllBaskets(): Promise<BasketOverview[]> {
   const { data, error } = await supabase
     .from("baskets")
     .select(
-      `id,name,raw_dump_id,status,tags,commentary,created_at,updated_at,blocks(count),raw_dumps(body_md)`
+      `
+        id,
+        name,
+        created_at,
+        raw_dump:raw_dump_id (
+          body_md
+        )
+      `
     )
     .order("created_at", { ascending: false });
   if (error) throw new Error(error.message);
   return (data ?? []).map((b: any) => ({
     id: b.id,
     name: b.name,
-    raw_dump_body: b.raw_dumps?.body_md ?? null,
+    raw_dump_body: b.raw_dump?.body_md ?? null,
     status: b.status,
     tags: b.tags,
     commentary: b.commentary,

--- a/web/lib/baskets/getRecentBaskets.ts
+++ b/web/lib/baskets/getRecentBaskets.ts
@@ -1,0 +1,6 @@
+import { getAllBaskets, BasketOverview } from './getAllBaskets';
+
+export async function getRecentBaskets(limit = 5): Promise<BasketOverview[]> {
+  const all = await getAllBaskets();
+  return all.slice(0, limit);
+}


### PR DESCRIPTION
## Summary
- fix basket query embed to avoid dual FK error
- add getRecentBaskets helper
- update orch_block_manager_agent for new postgrest-py API
- adjust stubs and tests for API change
- patch event log test for environment without pytest-asyncio

## Testing
- `pnpm lint --filter web`
- `uv run pytest -q`
- `pnpm lint && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6853f9aec5f483299994a761b660d9c0