### PR TITLE
Refresh basket docs after refactor

### DIFF
--- a/docs/API_BASKETS.md
+++ b/docs/API_BASKETS.md
@@ -10,23 +10,23 @@ Creates a new basket and saves context blocks + file references.
   "insight": "Targeting Gen Z, not millennials",
   "blocks": [
     {
-      "type": "topic",
+      "semantic_type": "topic",
       "label": "Launch spring campaign",
       "content": "Launch spring campaign",
       "is_primary": true,
       "meta_scope": "basket"
     },
     {
-      "type": "intent",
+      "semantic_type": "intent",
       "label": "Drive signups",
       "content": "Drive signups via social posts",
       "is_primary": true,
       "meta_scope": "basket"
     },
     {
-      "type": "reference",
+      "semantic_type": "reference",
       "label": "campaign_brief.pdf",
-      "content": "https://xyz.supabase.co/storage/v1/object/public/block-files/...",
+      "content": "https://xyz.supabase.co/storage/v1/object/public/block_files/...",
       "is_primary": true,
       "meta_scope": "basket",
       "source": "user_upload"
@@ -43,5 +43,7 @@ Creates a new basket and saves context blocks + file references.
 ```
 
 ## Notes
-- Uploaded files must already exist in `block-files` bucket before API call
-- Blocks are auto-linked to basket and ready for downstream orchestration
+- Uploaded files must already exist in `block_files` bucket before API call
+- The endpoint first persists the user input to **`raw_dumps`** and then
+  creates the `basket` referencing it via `raw_dump_id` (atomic intent capture).
+- Blocks are auto-linked to the basket and are ready for downstream orchestration

--- a/docs/BASKET_CREATION_FLOW.md
+++ b/docs/BASKET_CREATION_FLOW.md
@@ -12,12 +12,13 @@
 
 👑 **Purpose:** Persist basket and input, trigger orchestration agent.
 
-✅ **What happens:**  
-- Basket and input records inserted.  
-- Orchestration fires.  
+✅ **What happens:**
+- **Step 1 → raw_dump insert** (immutable capture)  
+- **Step 2 → basket insert** (FK `raw_dump_id` now satisfied)  
+- Orchestration agent fires.
 - Modality sidecar handling continues independently.
 
 ## Design Comments
 
-📌 Modalities are additive — their failure or delay does not block base basket creation.  
+📌 Modalities are additive — their failure or delay does _not_ block base basket creation.
 📌 Future modalities (e.g. audio) follow this same pattern, no further doc changes expected.

--- a/docs/BASKET_MANAGEMENT_FLOW.md
+++ b/docs/BASKET_MANAGEMENT_FLOW.md
@@ -13,7 +13,7 @@ Present the current state of the basket to the user.
 ✅ **What happens in this domain:**  
 - Fetch and display:
   - The original input (narrative view)
-  - Context blocks (promoted blocks)
+  - Blocks (promoted blocks)
   - Commit timeline (upload and agent processing history)
   - Pending change queue  
 - Provide a read-only view of the basket’s current structure and content.


### PR DESCRIPTION
## Summary
- update basket API doc to use `semantic_type`
- clarify raw dump insertion order and bucket naming
- sync creation flow notes with new raw dump/basket sequence
- tweak basket management flow wording

## Testing
- `npm run test`
- `pytest -q` *(fails: test_basket_new_error expected 500)*

------
https://chatgpt.com/codex/tasks/task_e_6855221f8e608329840b626f3b8e3804