### PR TITLE
Fix Makefile recipe tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ sync:
 
 .PHONY: format
 format:
-        uv run black .
+	uv run black .
 
 .PHONY: lint
 lint:
-        uv run ruff check
+	uv run ruff check
 
 .PHONY: mypy
 mypy: 


### PR DESCRIPTION
## Summary
- use real tabs for recipe lines in `Makefile`

## Testing
- `make lint` *(fails: Found 71 errors)*
- `make tests` *(fails: ModuleNotFoundError: No module named 'supabase_py')*

------
https://chatgpt.com/codex/tasks/task_e_685524ff1c7c8329b5c3fd31535d824e