### PR TITLE
Fix missing supabase_py client

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,3 +4,5 @@ pytest-asyncio
 pytest-mock
 ruff
 pre-commit
+supabase-py>=2.1.0
+httpx>=0.27.0

--- a/api/src/requirements.codex.txt
+++ b/api/src/requirements.codex.txt
@@ -10,13 +10,13 @@ fastapi>=0.110.0
 python-dotenv>=0.20.0,<1
 uvicorn>=0.34.0
 requests>=2.0,<3
-httpx>=0.24.0,<1
+httpx>=0.27.0
 griffe>=1.5.6,<2
 typing-extensions>=4.12.2,<5
 types-requests>=2.0,<3
 mkdocs-static-i18n>=1.3.0
 mcp>=1.6.0,<2; python_version >= "3.10"
-supabase
+supabase-py>=2.1.0
 jsonschema>=4.21
 asyncpg>=0.29.0
 httpx>=0.27.0

--- a/api/src/requirements.txt
+++ b/api/src/requirements.txt
@@ -12,17 +12,17 @@ fastapi>=0.110.0
 python-dotenv>=0.20.0,<1
 uvicorn>=0.34.0
 requests>=2.0,<3
-httpx>=0.24.0,<1
+httpx>=0.27.0
 griffe>=1.5.6,<2
 typing-extensions>=4.12.2,<5
 types-requests>=2.0,<3
 mkdocs-static-i18n>=1.3.0
 mcp>=1.6.0,<2; python_version >= "3.10"
-supabase
+supabase-py>=2.1.0
 jsonschema>=4.21
 asyncpg>=0.29.0
 
 # Phase 1 testing dependencies
-httpx
-supabase
+httpx>=0.27.0
+supabase-py>=2.1.0
 


### PR DESCRIPTION
## Summary
- pin supabase-py and httpx for API server

## Testing
- `uv run black .`
- `uv run ruff check` *(fails: B018, E501, UP035, F821, I001, F401, F841)*
- `PYTHONPATH=api/src uv run pytest` *(fails: ModuleNotFoundError: No module named 'supabase_py')*

------
https://chatgpt.com/codex/tasks/task_e_6855265569348329ba415243564c7624