### PR TITLE
fix: internalize auth_helpers and harden requirements

### DIFF
--- a/api/src/app/routes/basket_new.py
+++ b/api/src/app/routes/basket_new.py
@@ -17,7 +17,7 @@ from uuid import uuid4
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Depends
-from supabase.lib.auth_helpers import get_user
+from app.utils.auth_helpers import get_user
 from pydantic import BaseModel, Field
 from pydantic.config import ConfigDict
 

--- a/api/src/app/utils/auth_helpers.py
+++ b/api/src/app/utils/auth_helpers.py
@@ -1,0 +1,44 @@
+"""Authentication helper utilities.
+
+Provide dependencies for FastAPI routes using Supabase tokens.
+"""
+
+from __future__ import annotations
+
+import jwt
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from .supabase_client import get_supabase
+
+bearer = HTTPBearer()
+
+
+async def current_user_id(
+    creds: HTTPAuthorizationCredentials = Depends(bearer),
+) -> str:
+    """Decode Supabase JWT and return the user ID."""
+    token = creds.credentials
+    try:
+        payload = jwt.decode(token, options={"verify_signature": False})
+        user_id = payload.get("sub")
+        if not user_id:
+            raise KeyError
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=401, detail="Invalid or missing authentication token") from exc
+    return user_id
+
+
+async def get_user(
+    creds: HTTPAuthorizationCredentials = Depends(bearer),
+):
+    """Return the user object for the provided Supabase JWT."""
+    token = creds.credentials
+    supabase = get_supabase()
+    try:
+        user_response = supabase.auth.get_user(token)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=401, detail="Invalid or missing authentication token") from exc
+
+    # `get_user` may return a dataclass with a `user` attribute or the user dict directly
+    return getattr(user_response, "user", user_response)

--- a/api/src/requirements.txt
+++ b/api/src/requirements.txt
@@ -1,12 +1,8 @@
-#api/src/requirements.txt
+# ✅ requirements.codex.txt – Codex/CI-safe install list
 
-# Use GitHub-based OpenAI Agents SDK
 git+https://github.com/openai/openai-agents-python.git@91c62c1dea97d02ad4974947e572d634d42496d1#egg=openai-agents
 
-# Supabase — pin to working SHA (or your fork if using custom helpers)
-git+https://github.com/supabase-community/supabase-py.git@0f3250a085a78280076738f6541fcf034a7de381#egg=supabase
-
-# Core runtime
+# ── Core runtime ────────────────────────────────────────────────
 asyncpg>=0.29.0
 fastapi>=0.110.0
 httpx>=0.27.0
@@ -17,10 +13,13 @@ requests>=2.0,<3
 typing-extensions>=4.12.2,<5
 uvicorn>=0.34.0
 
-# Validation / schema
+# ── Supabase / storage ──────────────────────────────────────────
+git+https://github.com/supabase-community/supabase-py.git@0f3250a085a78280076738f6541fcf034a7de381#egg=supabase
+
+# ── Validation / schema ────────────────────────────────────────
 jsonschema>=4.21
 
-# Docs & tooling
+# ── Docs & tooling ─────────────────────────────────────────────
 griffe>=1.5.6,<2
 mcp>=1.6.0,<2; python_version >= "3.10"
 mkdocs-static-i18n>=1.3.0


### PR DESCRIPTION
## Summary
- move custom auth helpers into repo and update imports
- pin third-party dependencies and sync requirements files

## Testing
- `pip install -r api/src/requirements.txt`
- `uvicorn src.app.agent_server:app`

------
https://chatgpt.com/codex/tasks/task_e_68553c9aa348832992779b81285823f4