### PR TITLE
Fix publish_event imports and add supabase-py dependency

### DIFF
--- a/api/src/app/agent_tasks/layer1_infra/agents/infra_analyzer_agent.py
+++ b/api/src/app/agent_tasks/layer1_infra/agents/infra_analyzer_agent.py
@@ -7,7 +7,7 @@ from schemas.validators import validates
 from src.utils.logged_agent import logged
 
 from app.event_bus import DB_URL  # reuse same URL
-from app.supabase_helpers import publish_event
+from app.event_bus import publish_event
 
 from ..schemas import AuditReport, DuplicateLabel
 

--- a/api/src/app/agent_tasks/layer1_infra/agents/infra_observer_agent.py
+++ b/api/src/app/agent_tasks/layer1_infra/agents/infra_observer_agent.py
@@ -9,7 +9,7 @@ from schemas.validators import validates
 from src.utils.logged_agent import logged
 
 from app.event_bus import DB_URL
-from app.supabase_helpers import publish_event
+from app.event_bus import publish_event
 
 from ..schemas import UsageReport
 

--- a/api/src/app/agent_tasks/layer1_infra/agents/infra_research_agent.py
+++ b/api/src/app/agent_tasks/layer1_infra/agents/infra_research_agent.py
@@ -9,7 +9,7 @@ from src.app.agent_tasks.layer1_infra.utils.block_policy import insert_revision,
 from src.utils.logged_agent import logged
 
 from app.event_bus import DB_URL
-from app.supabase_helpers import publish_event
+from app.event_bus import publish_event
 
 from ..schemas import RefreshReport
 

--- a/api/src/app/agent_tasks/orchestration/orch_block_manager_agent.py
+++ b/api/src/app/agent_tasks/orchestration/orch_block_manager_agent.py
@@ -9,7 +9,7 @@ from schemas.validators import validates
 from src.utils.logged_agent import logged
 
 from app.event_bus import subscribe
-from app.supabase_helpers import publish_event
+from app.event_bus import publish_event
 
 DB_URL = os.getenv("DATABASE_URL")
 

--- a/api/src/app/routes/baskets.py
+++ b/api/src/app/routes/baskets.py
@@ -10,7 +10,7 @@ from schemas.context_block import ContextBlock
 from src.utils.db import json_safe
 
 from ..agent_tasks.layer1_infra.utils.supabase_helpers import get_supabase
-from ..supabase_helpers import publish_event
+from ..event_bus import publish_event
 
 router = APIRouter(prefix="/baskets", tags=["baskets"])
 

--- a/api/src/supabase_py/__init__.py
+++ b/api/src/supabase_py/__init__.py
@@ -1,0 +1,3 @@
+from supabase import create_client
+
+__all__ = ["create_client"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "python-dotenv>=0.20.0,<1",
     "uvicorn>=0.34.0",
     "supabase (>=2.15.1,<3.0.0)",
+    "supabase-py>=2,<3",
 ]
 
 classifiers = [


### PR DESCRIPTION
## Summary
- import `publish_event` from `app.event_bus` everywhere
- expose a small `supabase_py` shim so tests can import it
- add `supabase-py` to project dependencies

## Testing
- `PYTHONPATH=api/src api/.venv/bin/pytest -q tests/utils tests/agent_tasks tests/api`

------
https://chatgpt.com/codex/tasks/task_e_685561c178f0832982bb5291442adb2e