### PR TITLE
Bring back publish_event wrapper

### DIFF
--- a/api/src/app/supabase_helpers.py
+++ b/api/src/app/supabase_helpers.py
@@ -1,5 +1,5 @@
-from supabase import create_client
 from uuid import uuid4
+from .event_bus import emit   # ← keep original dependency
 
 
 def get_or_create_workspace(sb, user_id: str) -> str:
@@ -23,3 +23,14 @@ def get_or_create_workspace(sb, user_id: str) -> str:
         {"workspace_id": new_id, "user_id": user_id, "role": "owner"}
     ).execute()
     return new_id
+
+# --------------------------------------------------------------------
+# Legacy helper: forward to event_bus.emit so existing agents keep working
+# --------------------------------------------------------------------
+
+async def publish_event(topic: str, payload: dict) -> None:
+    """Thin wrapper kept for backward-compatibility."""
+    await emit(topic, payload)
+
+# Export both for star-imports
+__all__ = ["get_or_create_workspace", "publish_event"]


### PR DESCRIPTION
## Summary
- reintroduce `publish_event` helper as thin wrapper around `event_bus.emit`
- export both `get_or_create_workspace` and `publish_event` from `supabase_helpers`

## Testing
- `make tests` *(fails: ModuleNotFoundError/KeyError for Supabase env vars)*

------
https://chatgpt.com/codex/tasks/task_e_685562b075608329b7105f2d888ae249