### PR TITLE
Fix 403s by attaching JWT to browser requests

### DIFF
--- a/web/app/baskets/[id]/page.tsx
+++ b/web/app/baskets/[id]/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { createClient } from "@/lib/supabaseClient";
 import { Button } from "@/components/ui/Button";
 import Link from "next/link";
+import { fetchWithToken } from "@/lib/fetchWithToken";
 
 export default function BasketDetailPage({ params }: any) {
   const supabase = createClient();
@@ -12,7 +13,7 @@ export default function BasketDetailPage({ params }: any) {
 
   useEffect(() => {
     const fetchBasket = async () => {
-      const res = await fetch(`/api/baskets/${params.id}`);
+      const res = await fetchWithToken(`/api/baskets/${params.id}`);
       if (res.ok) {
         const json = await res.json();
         setBasket(json);

--- a/web/components/work/BlocksWorkspace.tsx
+++ b/web/components/work/BlocksWorkspace.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import BlocksList from "./BlocksList";
 import { usePendingChanges } from "@/lib/baskets/usePendingChanges";
+import { fetchWithToken } from "@/lib/fetchWithToken";
 
 interface Props {
     basketId: string;
@@ -16,7 +17,7 @@ export default function BlocksWorkspace({
     const [summary, setSummary] = useState<string | null>(null);
 
     const handleSummarizeSession = async () => {
-        const res = await fetch("/api/summarize-session", {
+        const res = await fetchWithToken("/api/summarize-session", {
             method: "POST",
             body: JSON.stringify({ basket_id: basketId }),
         });

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -4,6 +4,7 @@
  * Simple wrapper for GET requests to the backend API.
  * Uses the Next.js rewrite from /api to the configured API base.
  */
+import { fetchWithToken } from "@/lib/fetchWithToken";
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "";
 
 function withBase(path: string) {
@@ -11,7 +12,7 @@ function withBase(path: string) {
 }
 
 export async function apiGet<T = any>(path: string): Promise<T> {
-  const res = await fetch(withBase(path));
+  const res = await fetchWithToken(withBase(path));
   // Handle non-OK responses
   if (!res.ok) {
     console.warn(`[apiGet] Non-OK response (${res.status}) for ${path}`);
@@ -30,7 +31,7 @@ export async function apiGet<T = any>(path: string): Promise<T> {
 }
 
 export async function apiPost<T = any>(path: string, body: any): Promise<T> {
-  const res = await fetch(withBase(path), {
+  const res = await fetchWithToken(withBase(path), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -43,7 +44,7 @@ export async function apiPost<T = any>(path: string, body: any): Promise<T> {
 }
 
 export async function apiPut<T = any>(path: string, body: any): Promise<T> {
-  const res = await fetch(withBase(path), {
+  const res = await fetchWithToken(withBase(path), {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),

--- a/web/lib/baskets/createBasketNew.ts
+++ b/web/lib/baskets/createBasketNew.ts
@@ -3,6 +3,7 @@ export interface NewBasketArgs {
   file_urls?: string[];
 }
 import { createClient } from "@/lib/supabaseClient";
+import { fetchWithToken } from "@/lib/fetchWithToken";
 export async function createBasketNew(
   args: NewBasketArgs,
 ): Promise<{ id: string }> {
@@ -13,7 +14,7 @@ export async function createBasketNew(
   const uid = data.session?.user.id;
   if (uid) headers['X-User-Id'] = uid;
   const body = { text_dump: args.text_dump, file_urls: args.file_urls ?? [] };
-  const res = await fetch(`${base}/api/baskets/new`, {
+  const res = await fetchWithToken(`${base}/api/baskets/new`, {
     method: 'POST',
     headers,
     body: JSON.stringify(body),

--- a/web/lib/baskets/dumpApi.ts
+++ b/web/lib/baskets/dumpApi.ts
@@ -1,4 +1,4 @@
-import { apiPost } from "@/lib/api";
+import { fetchWithToken } from "@/lib/fetchWithToken";
 
 interface PostDumpArgs {
   basketId: string;
@@ -27,7 +27,7 @@ export async function postDump({
   if (text) form.append("text", text);
   for (const img of images) form.append("file", img, img.name);
 
-  const res = await fetch("/api/dump", { method: "POST", body: form });
+  const res = await fetchWithToken("/api/dump", { method: "POST", body: form });
   if (!res.ok) {
     const msg = await res.text();
     throw new Error(msg || `Dump upload failed (${res.status})`);

--- a/web/lib/baskets/getAllBaskets.ts
+++ b/web/lib/baskets/getAllBaskets.ts
@@ -1,15 +1,15 @@
-import { createClient } from "@/lib/supabaseClient";
 import { Database } from "@/lib/dbTypes";
+import { fetchWithToken } from "@/lib/fetchWithToken";
 
 export type BasketOverview =
   Database["public"]["Views"]["v_basket_overview"]["Row"];
 
 export async function getAllBaskets() {
-  const supabase = createClient();
-  const { data, error } = await supabase
-    .from("v_basket_overview")
-    .select("*")
-    .order("created_at", { ascending: false });
-  if (error) throw error;
-  return data as BasketOverview[];
+  const url = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1/v_basket_overview?select=*&order=created_at.desc`;
+  const res = await fetchWithToken(url);
+  if (!res.ok) {
+    const msg = await res.text();
+    throw new Error(msg || `getAllBaskets failed (${res.status})`);
+  }
+  return (await res.json()) as BasketOverview[];
 }

--- a/web/lib/dumps/createDump.ts
+++ b/web/lib/dumps/createDump.ts
@@ -1,7 +1,8 @@
 import { Database } from "../dbTypes";
+import { fetchWithToken } from "@/lib/fetchWithToken";
 
 export async function createDump(basketId: string, text_dump: string, file_urls: string[] = []): Promise<{ raw_dump_id: string }> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/dumps/new`, {
+  const res = await fetchWithToken(`${process.env.NEXT_PUBLIC_API_BASE_URL}/dumps/new`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ basket_id: basketId, text_dump, file_urls }),

--- a/web/lib/fetchWithToken.ts
+++ b/web/lib/fetchWithToken.ts
@@ -1,0 +1,21 @@
+import { createClient } from "@/lib/supabaseClient";
+
+export async function fetchWithToken(
+  input: RequestInfo | URL,
+  init: RequestInit = {}
+) {
+  const supabase = createClient();
+  const { data: { session } } = await supabase.auth.getSession();
+  const token = session?.access_token ?? "";
+  return fetch(input, {
+    ...init,
+    headers: {
+      ...(init.headers || {}),
+      "sb-access-token": token,
+      Authorization: `Bearer ${token}`,
+      apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+}


### PR DESCRIPTION
## Summary
- add `fetchWithToken` utility
- use it when creating baskets and listing basket overview
- update API helpers and UI calls to send Supabase tokens

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test`
- `make lint` *(fails to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68561b47499c83298965b7a75c010566