### PR TITLE
Fix user.id access + pin supabase-py safely

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,5 +4,5 @@ pytest-asyncio
 pytest-mock
 ruff
 pre-commit
-supabase-py>=2.1.0
+supabase-py==2.1.*
 httpx>=0.27.0

--- a/api/src/app/routes/basket_new.py
+++ b/api/src/app/routes/basket_new.py
@@ -55,7 +55,10 @@ async def create_basket(
 
     log.info("[basket_new] payload: %s", payload.model_dump())
 
-    workspace_id = get_or_create_workspace(supabase, user["id"])
+    user_id = getattr(user, "id", None) or user.get("id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Unauthenticated")
+    workspace_id = get_or_create_workspace(supabase, user_id)
 
     dump_resp = supabase.table("raw_dumps").insert(
         {


### PR DESCRIPTION
## Summary
- handle user object variations when creating baskets
- pin `supabase-py` to `2.1.*`

## Testing
- `make lint` *(fails: No solution found when resolving dependencies)*
- `make format` *(fails: No solution found when resolving dependencies)*
- `make tests` *(fails: No solution found when resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68561f1f17a08329a75cf040fd1322ef