### PR TITLE
Proxy Supabase REST calls and harden basket creation

### DIFF
--- a/api/src/app/routes/basket_new.py
+++ b/api/src/app/routes/basket_new.py
@@ -59,6 +59,9 @@ async def create_basket(
         except ValidationError as e:
             raise HTTPException(status_code=400, detail=e.errors()) from e
 
+    if mode == "v1" and not body_v1.text_dump.strip():
+        raise HTTPException(status_code=400, detail="text_dump is empty")
+
     # workspace is the only source of truth for ownership
     workspace_id = get_or_create_workspace(user["user_id"])
 

--- a/api/src/app/routes/basket_snapshot.py
+++ b/api/src/app/routes/basket_snapshot.py
@@ -76,3 +76,9 @@ def get_basket_snapshot(basket_id: str) -> dict:
     snapshot = assemble_snapshot(raw_dumps, blocks)  # returns dict
     snapshot["basket"] = basket
     return snapshot
+
+
+@router.get("/snapshot/{basket_id}")
+def get_basket_snapshot_service(basket_id: str) -> dict:
+    """Expose snapshot via a stable path using the service role."""
+    return get_basket_snapshot(basket_id)

--- a/tests/dump_hotkey.spec.ts
+++ b/tests/dump_hotkey.spec.ts
@@ -18,6 +18,6 @@ test('dump hotkey saves dump', async ({ page }) => {
   await page.locator('textarea').fill('hello world');
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(page.getByText('Dump saved')).toBeVisible();
-  const snap = await page.request.get(`/api/baskets/${basketId}/snapshot`);
+  const snap = await page.request.get(`/api/baskets/snapshot/${basketId}`);
   expect(snap.status()).toBe(200);
 });

--- a/web/app/api/baskets/snapshot/[id]/route.ts
+++ b/web/app/api/baskets/snapshot/[id]/route.ts
@@ -6,7 +6,7 @@ export async function GET(req: NextRequest, ctx: any) {
     return NextResponse.json({ error: 'Missing NEXT_PUBLIC_API_BASE' }, { status: 500 });
   }
   const { id } = ctx.params;
-  const upstream = `${baseUrl}/baskets/${id}/snapshot`;
+  const upstream = `${baseUrl}/baskets/snapshot/${id}`;
   const headers: HeadersInit = {};
   const auth = req.headers.get('authorization');
   if (auth) headers['Authorization'] = auth;

--- a/web/generated-route-registry.json
+++ b/web/generated-route-registry.json
@@ -15,6 +15,6 @@
   "/api/system-check",
   "/api/task-types",
   "/api/baskets/new",
-  "/api/baskets/[id]/snapshot",
+  "/api/baskets/snapshot/[id]",
   "/api/agents/[name]/run"
 ]

--- a/web/lib/baskets/createBasketNew.ts
+++ b/web/lib/baskets/createBasketNew.ts
@@ -14,6 +14,11 @@ export interface NewBasketArgs {
 export async function createBasketNew(
   args: NewBasketArgs,
 ): Promise<{ id: string }> {
+  console.debug("[createBasketNew] text_dump:", args.text_dump);
+  if (!args.text_dump || args.text_dump.trim().length === 0) {
+    console.warn("[createBasketNew] text_dump is empty");
+    throw new Error("text_dump cannot be empty");
+  }
   /* ── 1️⃣  get the caller’s JWT for the backend ─────────────────────────── */
   const supabase = createClient();
   const { data } = await supabase.auth.getSession();

--- a/web/lib/baskets/getSnapshot.ts
+++ b/web/lib/baskets/getSnapshot.ts
@@ -20,11 +20,11 @@ export interface BasketSnapshot {
   }[];
 }
 
-const SNAPSHOT_PATH = "snapshot";               // route segment
+const SNAPSHOT_PREFIX = "/api/baskets/snapshot";
 
 export async function getSnapshot(id: string): Promise<BasketSnapshot> {
   // NOTE: fetchWithToken itself prepends API_ORIGIN, so we pass a bare path.
-  const res = await fetchWithToken(`/api/baskets/${id}/${SNAPSHOT_PATH}`);
+  const res = await fetchWithToken(`${SNAPSHOT_PREFIX}/${id}`);
   if (!res.ok) {
     const msg = await res.text();
     throw new Error(msg || `snapshot fetch failed (${res.status})`);

--- a/web/route-contracts.json
+++ b/web/route-contracts.json
@@ -15,6 +15,6 @@
   "/api/system-check",
   "/api/task-types",
   "/api/baskets/new",
-  "/api/baskets/[id]/snapshot",
+  "/api/baskets/snapshot/[id]",
   "/api/agents/[name]/run"
 ]

--- a/web/tests/e2e/run_blockifier.spec.ts
+++ b/web/tests/e2e/run_blockifier.spec.ts
@@ -22,7 +22,7 @@ const secondSnapshot = {
 
 test('run blockifier flow', async ({ page }) => {
   let snapCall = 0;
-  await page.route('**/baskets/test-basket/snapshot', async (route) => {
+  await page.route('**/baskets/snapshot/test-basket', async (route) => {
     snapCall += 1;
     await route.fulfill({
       status: 200,


### PR DESCRIPTION
## Summary
- validate `text_dump` before creating basket and add proxy snapshot route
- log dump data before posting
- fetch snapshot via `/api/baskets/snapshot/<id>` path
- update tests and route registry to use new snapshot path

## Testing
- `make lint` *(fails: No solution found when resolving dependencies)*
- `npm run build` in `web` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569042ca208329b5b7d0500e588c7a