### PR TITLE
Split Supabase server/browser clients to avoid build errors

### DIFF
--- a/web/app/baskets/[id]/page.tsx
+++ b/web/app/baskets/[id]/page.tsx
@@ -1,12 +1,10 @@
 "use client";
 import { useEffect, useState } from "react";
-import { createClient } from "@/lib/supabaseClient";
 import { Button } from "@/components/ui/Button";
 import Link from "next/link";
 import { apiGet } from "@/lib/api";
 
 export default function BasketDetailPage({ params }: any) {
-  const supabase = createClient();
   const [basket, setBasket] = useState<any>(null);
   const [blocks, setBlocks] = useState<any[]>([]);
   const [configs, setConfigs] = useState<any[]>([]);

--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -1,7 +1,6 @@
 import { getSnapshot } from "@/lib/baskets/getSnapshot";
-import { cookies } from "next/headers";
 import BasketWorkClient from "./BasketWorkClient";
-import { createServerSupabaseClient } from "@/lib/supabaseClient";
+import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
 
 // Match Next 15's PageProps expectation: `params` is a Promise.
 interface PageProps {
@@ -12,8 +11,7 @@ export default async function BasketWorkPage({ params }: PageProps) {
   // Unwrap the promise that Next hands us
   const { id } = await params;
 
-  const cookieStore = await cookies();
-  const supabase = createServerSupabaseClient(cookieStore);
+  const supabase = createServerSupabaseClient();
 
   const {
     data: { session },

--- a/web/app/components/layout/Sidebar.tsx
+++ b/web/app/components/layout/Sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import clsx from "clsx";
-import { createClient } from "@/lib/supabaseClient";
+import { supabase } from "@/lib/supabaseClient";
 import { useEffect, useState } from "react";
 import { X } from "lucide-react";
 
@@ -23,7 +23,6 @@ interface SidebarProps {
 const Sidebar = ({ open, onClose }: SidebarProps) => {
   const pathname = usePathname();
   const router = useRouter();
-  const supabase = createClient();
   const [userEmail, setUserEmail] = useState<string | null>(null);
 
   useEffect(() => {

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -3,13 +3,12 @@
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { createClient } from "@/lib/supabaseClient";
+import { supabase } from "@/lib/supabaseClient";
 import { Button } from "@/components/ui/Button";
 import Brand from "@/components/Brand";
 
 export default function LoginPage() {
   const router = useRouter();
-  const supabase = createClient();
   const [email, setEmail] = useState("");
   const [sent, setSent] = useState(false);
   const [errorMsg, setErrorMsg] = useState("");

--- a/web/app/queue/page.tsx
+++ b/web/app/queue/page.tsx
@@ -5,7 +5,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClient } from "@/lib/supabaseClient";
+import { supabase } from "@/lib/supabaseClient";
 import { Button } from "@/components/ui/Button";
 
 interface QueueRow {
@@ -19,7 +19,6 @@ interface QueueRow {
 }
 
 export default function BlockQueuePage() {
-  const supabase = createClient();
   const [rows, setRows] = useState<QueueRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [scopeFilter, setScopeFilter] = useState<'all' | 'basket' | 'agent' | 'profile'>('all');

--- a/web/components/ChatPane.tsx
+++ b/web/components/ChatPane.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { createClient } from "@/lib/supabaseClient";
+import { supabase } from "@/lib/supabaseClient";
 import { ClarificationResponse } from "@/components/ClarificationResponse";
 
 interface ChatPaneProps {
@@ -26,7 +26,6 @@ export function ChatPane({ taskId, collectedInputs, onClarificationSubmit }: Cha
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const supabase = createClient();
 
     // Load existing messages
     supabase

--- a/web/components/SupabaseProvider.tsx
+++ b/web/components/SupabaseProvider.tsx
@@ -2,7 +2,7 @@
 
 import { ReactNode, useState } from "react";
 import { SessionContextProvider } from "@supabase/auth-helpers-react";
-import { createClient } from "@/lib/supabaseClient";
+import { supabase } from "@/lib/supabaseClient";
 
 interface SupabaseProviderProps {
   children: ReactNode;
@@ -12,7 +12,7 @@ interface SupabaseProviderProps {
  * SupabaseProvider wraps the app with SessionContextProvider for Supabase auth.
  */
 export default function SupabaseProvider({ children }: SupabaseProviderProps) {
-  const [supabaseClient] = useState(() => createClient());
+  const [supabaseClient] = useState(() => supabase);
   return (
     <SessionContextProvider supabaseClient={supabaseClient}>
       {children}

--- a/web/components/UserNav.tsx
+++ b/web/components/UserNav.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { createClient } from "@/lib/supabaseClient";
+import { supabase } from "@/lib/supabaseClient";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { User as UserIcon } from "lucide-react";
@@ -18,7 +18,6 @@ interface UserNavProps {
 
 export default function UserNav({ compact = false }: UserNavProps) {
   const router = useRouter();
-  const supabase = createClient();
   const [user, setUser] = useState<User | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);

--- a/web/components/blocks/BlockCreateModal.tsx
+++ b/web/components/blocks/BlockCreateModal.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
-import { createClient } from "@/lib/supabaseClient";
+import { supabase } from "@/lib/supabaseClient";
 
 interface Props {
   open: boolean;
@@ -33,7 +33,6 @@ export default function BlockCreateModal({ open, onOpenChange, onCreate }: Props
 
   useEffect(() => {
     if (!open) return;
-    const supabase = createClient();
     supabase
       .from("blocks")
       .select("type")

--- a/web/components/library/UploadArea.tsx
+++ b/web/components/library/UploadArea.tsx
@@ -4,7 +4,7 @@
 
 import { useState, useRef } from "react";
 import { useSessionContext } from "@supabase/auth-helpers-react";
-import { createClient } from "@/lib/supabaseClient";
+import { supabase } from "@/lib/supabaseClient";
 import { insertBlockFile } from "@/lib/insertBlockFile";
 import { Button } from "@/components/ui/Button";
 import { Progress } from "@/components/library/progress";
@@ -13,7 +13,6 @@ export function UploadArea({ onUpload }: { onUpload: () => void }) {
   const [uploading, setUploading] = useState(false);
   const [progress, setProgress] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
-  const supabase = createClient();
   const { session } = useSessionContext();
 
   const handleFiles = async (files: FileList) => {

--- a/web/components/settings/ProfileTab.tsx
+++ b/web/components/settings/ProfileTab.tsx
@@ -2,11 +2,10 @@
 
 import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/Input";
-import { createClient } from "@/lib/supabaseClient";
+import { supabase } from "@/lib/supabaseClient";
 import type { User } from "@supabase/supabase-js";
 
 export default function ProfileTab() {
-  const supabase = createClient();
   const [user, setUser] = useState<User | null>(null);
 
   useEffect(() => {

--- a/web/lib/supabaseClient.ts
+++ b/web/lib/supabaseClient.ts
@@ -1,31 +1,12 @@
-// web/lib/supabaseClient.ts
-
-import { createServerComponentClient, createPagesBrowserClient } from "@supabase/auth-helpers-nextjs";
+import { createPagesBrowserClient } from "@supabase/auth-helpers-nextjs";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "./dbTypes";
-import { cookies } from "next/headers";
 
-/**
- * Factory for server-side Supabase client
- * — Uses Next.js App Router's server component pattern
- */
-export const createServerSupabaseClient = (): SupabaseClient<Database> =>
-  createServerComponentClient<Database>({ cookies });
-
-/**
- * Factory for browser-side Supabase client
- */
 export const createBrowserSupabaseClient = (): SupabaseClient<Database> =>
   createPagesBrowserClient<Database>();
 
-/**
- * Legacy alias used in client-side codebase
- */
 export const createClient = createBrowserSupabaseClient;
 
-/**
- * Shared browser-side client instance
- */
 export const supabase = createClient();
 
 export default supabase;

--- a/web/lib/supabaseServerClient.ts
+++ b/web/lib/supabaseServerClient.ts
@@ -1,0 +1,11 @@
+import { createServerClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "./dbTypes";
+import { cookies } from "next/headers";
+
+export const createServerSupabaseClient = (): SupabaseClient<Database> =>
+  createServerClient<Database>(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_ANON_KEY!,
+    { cookies }
+  );


### PR DESCRIPTION
## Summary
- add `web/lib/supabaseServerClient.ts` for server-only Supabase API
- simplify `web/lib/supabaseClient.ts` to only expose browser helpers
- update server page to use `createServerSupabaseClient`
- update client components to import the shared `supabase` instance

## Testing
- `pre-commit run --files web/app/baskets/[id]/page.tsx web/app/baskets/[id]/work/page.tsx web/app/components/layout/Sidebar.tsx web/app/login/page.tsx web/app/queue/page.tsx web/components/ChatPane.tsx web/components/SupabaseProvider.tsx web/components/UserNav.tsx web/components/blocks/BlockCreateModal.tsx web/components/library/UploadArea.tsx web/components/settings/ProfileTab.tsx web/lib/supabaseClient.ts web/lib/supabaseServerClient.ts`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6858f0c80f30832995a22def89780640