### PR TITLE
Fix await params and cookies usage in baskets routes

### DIFF
--- a/web/app/baskets/[id]/layout.tsx
+++ b/web/app/baskets/[id]/layout.tsx
@@ -5,8 +5,8 @@ export default async function BasketLayout({
   params,
 }: {
   children: React.ReactNode;
-  params: any;
+  params: Promise<{ id: string }>;
 }) {
-  const { id } = params as { id: string };
+  const { id } = await params;
   return <BasketProvider initialBasketId={id}>{children}</BasketProvider>;
 }

--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -1,6 +1,7 @@
 import { getSnapshot } from "@/lib/baskets/getSnapshot";
 import BasketWorkClient from "./BasketWorkClient";
 import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
+import { cookies } from "next/headers";
 
 // Match Next 15's PageProps expectation: `params` is a Promise.
 interface PageProps {
@@ -10,6 +11,7 @@ interface PageProps {
 export default async function BasketWorkPage({ params }: PageProps) {
   // Unwrap the promise that Next hands us
   const { id } = await params;
+  const cookieStore = cookies();
 
   const supabase = createServerSupabaseClient();
 


### PR DESCRIPTION
## Summary
- fix BasketLayout to await `params`
- update BasketWorkPage to await params and call `cookies()`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f383e67b883298811d5b17e4cad31