### PR TITLE
Fix create block route

### DIFF
--- a/api/src/app/routes/context_blocks_create.py
+++ b/api/src/app/routes/context_blocks_create.py
@@ -22,7 +22,7 @@ class BlockCreateRequest(BaseModel):
     state: str = "PROPOSED"
 
 
-@router.post("/api/context-blocks/create")
+@router.post("/context-blocks/create")
 async def create_context_block(req: BlockCreateRequest):
     try:
         block_id = str(uuid4())


### PR DESCRIPTION
## Summary
- correct the path for creating blocks so there's no double prefix

## Testing
- `make lint` *(fails: No solution found when resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6862c91178f48329a6b3af7dd7e74f74