### PR TITLE
Implement route-aware sidebar

### DIFF
--- a/web/app/components/layout/Sidebar.tsx
+++ b/web/app/components/layout/Sidebar.tsx
@@ -6,6 +6,7 @@ import clsx from "clsx";
 import { supabase } from "@/lib/supabaseClient";
 import { useEffect, useState } from "react";
 import { X } from "lucide-react";
+import { useSidebarStore } from "@/lib/stores/sidebarStore";
 
 const baseItems = [
   { href: "/dashboard", label: "🧶 Dashboard" },
@@ -17,13 +18,11 @@ const baseItems = [
 ];
 
 interface SidebarProps {
-  open: boolean;
-  onClose: () => void;
-  collapsible?: boolean;
   className?: string;
 }
 
-const Sidebar = ({ open, onClose, collapsible = false, className }: SidebarProps) => {
+const Sidebar = ({ className }: SidebarProps) => {
+  const { isOpen, collapsible, closeSidebar } = useSidebarStore();
   const pathname = usePathname();
   const router = useRouter();
   const [userEmail, setUserEmail] = useState<string | null>(null);
@@ -37,6 +36,17 @@ const Sidebar = ({ open, onClose, collapsible = false, className }: SidebarProps
     };
     getSession();
   }, [supabase]);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (!collapsible) return;
+      if (!(e.target as HTMLElement).closest('.sidebar')) {
+        closeSidebar();
+      }
+    }
+    document.addEventListener('click', handleClickOutside);
+    return () => document.removeEventListener('click', handleClickOutside);
+  }, [collapsible, closeSidebar]);
 
   const handleLogout = async () => {
     await supabase.auth.signOut();
@@ -59,9 +69,9 @@ const Sidebar = ({ open, onClose, collapsible = false, className }: SidebarProps
   return (
     <aside
       className={clsx(
-        "fixed top-0 left-0 z-50 h-screen w-64 bg-background border-r border-border shadow-md transform transition-transform",
+        "sidebar fixed top-0 left-0 z-50 h-screen w-64 bg-background border-r border-border shadow-md transform transition-transform",
         collapsible ? "md:fixed" : "md:relative md:block md:min-h-screen",
-        open ? "translate-x-0" : "-translate-x-full",
+        isOpen ? "translate-x-0" : "-translate-x-full",
         !collapsible && "md:translate-x-0",
         className
       )}
@@ -71,7 +81,7 @@ const Sidebar = ({ open, onClose, collapsible = false, className }: SidebarProps
           "absolute top-3 left-3 p-1 rounded-md hover:bg-muted",
           !collapsible && "md:hidden"
         )}
-        onClick={onClose}
+        onClick={closeSidebar}
         aria-label="Close sidebar"
       >
         <X className="h-5 w-5" />

--- a/web/components/layout/AppLayout.tsx
+++ b/web/components/layout/AppLayout.tsx
@@ -1,10 +1,12 @@
 "use client";
 import { ReactNode } from "react";
 import { useFileDrag } from "@/hooks/useFileDrag";
+import { useAutoSidebarBehavior } from "@/hooks/useAutoSidebarBehavior";
 import { FileDropOverlay } from "@/components/FileDropOverlay";
 
 export default function AppLayout({ children }: { children: ReactNode }) {
   const { isDraggingFile } = useFileDrag();
+  useAutoSidebarBehavior();
 
   function noopDropHandler(e: React.DragEvent) {
     e.preventDefault();

--- a/web/components/layouts/Shell.tsx
+++ b/web/components/layouts/Shell.tsx
@@ -1,9 +1,10 @@
 "use client";
-import React, { ReactNode, useEffect, useState } from "react";
+import React, { ReactNode, useEffect } from "react";
 import Sidebar from "@/app/components/layout/Sidebar";
 import MobileSidebarToggle from "@/components/MobileSidebarToggle";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
+import { useSidebarStore } from "@/lib/stores/sidebarStore";
 
 interface ShellProps {
     children: ReactNode;
@@ -15,39 +16,42 @@ export default function Shell({ children, collapseSidebar = false }: ShellProps)
     const hideSidebarByPath =
         pathname?.includes("/baskets/") &&
         (pathname.endsWith("/work") || pathname.endsWith("/work-dev"));
-    const shouldCollapse = collapseSidebar || hideSidebarByPath;
     const forceShowHamburger = hideSidebarByPath;
-    const [sidebarVisible, setSidebarVisible] = useState(!hideSidebarByPath);
+    const { isOpen, openSidebar, closeSidebar, collapsible } = useSidebarStore();
+
+    useEffect(() => {
+        if (hideSidebarByPath) {
+            closeSidebar();
+        } else {
+            openSidebar();
+        }
+    }, [hideSidebarByPath, openSidebar, closeSidebar]);
 
     useEffect(() => {
         const handleEsc = (e: KeyboardEvent) => {
-            if (e.key === "Escape") setSidebarVisible(false);
+            if (e.key === "Escape") closeSidebar();
         };
         window.addEventListener("keydown", handleEsc);
         return () => window.removeEventListener("keydown", handleEsc);
-    }, []);
+    }, [closeSidebar]);
+
+    const shouldCollapse = collapsible || hideSidebarByPath || collapseSidebar;
 
     return (
         <div className="min-h-screen md:flex">
             {/* Screen overlay */}
-            {sidebarVisible && shouldCollapse && (
+            {isOpen && shouldCollapse && (
                 <div
                     className="fixed inset-0 z-40 bg-black/50 md:hidden"
-                    onClick={() => setSidebarVisible(false)}
+                    onClick={closeSidebar}
                 />
             )}
-            {sidebarVisible && (
-                <Sidebar
-                    open={true}
-                    onClose={() => setSidebarVisible(false)}
-                    collapsible={shouldCollapse}
-                />
-            )}
+            {isOpen && <Sidebar />}
             <main className="p-6 flex-1">
                 <div className={cn("mb-4", shouldCollapse ? undefined : "md:hidden")}
                 >
                     <MobileSidebarToggle
-                        onClick={() => setSidebarVisible(!sidebarVisible)}
+                        onClick={() => (isOpen ? closeSidebar() : openSidebar())}
                         forceShow={forceShowHamburger}
                     />
                 </div>

--- a/web/hooks/useAutoSidebarBehavior.ts
+++ b/web/hooks/useAutoSidebarBehavior.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
+import { useSidebarStore } from '@/lib/stores/sidebarStore'
+
+export function useAutoSidebarBehavior() {
+  const pathname = usePathname()
+  const setCollapsible = useSidebarStore((s) => s.setCollapsible)
+
+  useEffect(() => {
+    const shouldCollapse = pathname.startsWith('/baskets') || pathname.startsWith('/blocks')
+    setCollapsible(shouldCollapse)
+  }, [pathname, setCollapsible])
+}

--- a/web/lib/stores/sidebarStore.ts
+++ b/web/lib/stores/sidebarStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand'
+
+interface SidebarState {
+  isOpen: boolean
+  collapsible: boolean
+  openSidebar: () => void
+  closeSidebar: () => void
+  setCollapsible: (value: boolean) => void
+}
+
+export const useSidebarStore = create<SidebarState>((set) => ({
+  isOpen: true,
+  collapsible: false,
+  openSidebar: () => set({ isOpen: true }),
+  closeSidebar: () => set({ isOpen: false }),
+  setCollapsible: (value) => set({ collapsible: value }),
+}))

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -35,7 +35,8 @@
         "swr": "^2.2.0",
         "tailwind-merge": "^3.3.0",
         "tailwindcss-animate": "^1.0.7",
-        "zod": "^3.24.4"
+        "zod": "^3.24.4",
+        "zustand": "^4.5.2"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -9677,6 +9678,34 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/web/package.json
+++ b/web/package.json
@@ -34,6 +34,7 @@
     "react-markdown": "^8.0.7",
     "remark-gfm": "^4.0.1",
     "swr": "^2.2.0",
+    "zustand": "^4.5.2",
     "tailwind-merge": "^3.3.0",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.24.4"


### PR DESCRIPTION
## Summary
- add global sidebar store using Zustand
- auto-collapse sidebar based on current route
- wire AutoSidebarBehavior into AppLayout
- switch Shell and Sidebar to use global store
- add zustand to frontend dependencies

## Testing
- `make format` *(fails: No solution found when resolving dependencies)*
- `make lint` *(fails: No solution found when resolving dependencies)*
- `make tests` *(fails: No solution found when resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e043fea508329a4fe14a6d77dace7