### PR TITLE
Add basket sidebar layout

### DIFF
--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -23,7 +23,7 @@ export default async function BasketWorkPage({ params }: PageProps) {
 
   const { data: basket } = await supabase
     .from("baskets")
-    .select("id, name, created_at")
+    .select("id, name, status, tags")
     .eq("id", id)
     .single();
 
@@ -55,6 +55,12 @@ export default async function BasketWorkPage({ params }: PageProps) {
 
 
   return (
-    <BasketDashboardLayout basketId={id} dumpBody={rawDumpBody} />
+    <BasketDashboardLayout
+      basketId={id}
+      basketName={basket.name ?? "Untitled"}
+      status={basket.status ?? "draft"}
+      scope={basket.tags ?? []}
+      dumpBody={rawDumpBody}
+    />
   );
 }

--- a/web/components/basket/BasketSidebar.tsx
+++ b/web/components/basket/BasketSidebar.tsx
@@ -1,0 +1,38 @@
+"use client";
+import BasketSidebarHeader from "./BasketSidebarHeader";
+import Link from "next/link";
+
+interface Props {
+  basketId: string;
+  basketName: string;
+  status: string;
+  scope: string[];
+}
+
+export default function BasketSidebar({
+  basketId,
+  basketName,
+  status,
+  scope,
+}: Props) {
+  return (
+    <aside className="w-[260px] border-r shrink-0 flex flex-col p-4 space-y-6">
+      <BasketSidebarHeader
+        basketName={basketName}
+        status={status}
+        scope={scope}
+      />
+      <nav className="flex flex-col gap-2 text-sm">
+        <Link href={`/baskets/${basketId}/work`}>Dashboard</Link>
+        <Link href={`/baskets/${basketId}/insights`}>Insights</Link>
+        <Link href={`/baskets/${basketId}/history`}>History</Link>
+      </nav>
+      <div className="text-xs font-semibold text-muted-foreground space-y-2">
+        <p>Context Items</p>
+        <p>Text Blocks</p>
+        <p>Documents</p>
+        <p>Raw Dumps</p>
+      </div>
+    </aside>
+  );
+}

--- a/web/components/basket/BasketSidebarHeader.tsx
+++ b/web/components/basket/BasketSidebarHeader.tsx
@@ -10,7 +10,7 @@ interface Props {
     isRunningBlockifier?: boolean;
 }
 
-export default function BasketHeader({
+export default function BasketSidebarHeader({
     basketName,
     status,
     scope,

--- a/web/components/layouts/BasketDashboardLayout.tsx
+++ b/web/components/layouts/BasketDashboardLayout.tsx
@@ -1,34 +1,51 @@
 import DocumentList from "@/components/documents/DocumentList";
+import BasketSidebar from "@/components/basket/BasketSidebar";
 import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
 import { EmptyState } from "@/components/ui/EmptyState";
 
 interface Props {
   basketId: string;
+  basketName: string;
+  status: string;
+  scope: string[];
   dumpBody?: string;
 }
 
-export default function BasketDashboardLayout({ basketId, dumpBody }: Props) {
+export default function BasketDashboardLayout({
+  basketId,
+  basketName,
+  status,
+  scope,
+  dumpBody,
+}: Props) {
   return (
-    <div className="md:flex w-full min-h-screen">
-      {/* Sidebar document list for desktop */}
-      <aside className="hidden md:block w-[220px] shrink-0 border-r overflow-y-auto">
-        <div className="flex flex-col h-full">
-          <DocumentList basketId={basketId} />
-          <div className="p-4 border-t">
-            <Button size="sm" disabled className="w-full">
-              + Create Document
-            </Button>
-          </div>
-        </div>
-      </aside>
-      {/* Main dashboard content */}
-      <div className="flex-1 p-4 space-y-6">
-        {/* Mobile document list */}
-        <section className="md:hidden">
-          <h2 className="font-medium mb-2">Documents</h2>
-          <Card className="p-4">
+    <div className="flex h-full w-full">
+      <BasketSidebar
+        basketId={basketId}
+        basketName={basketName}
+        status={status}
+        scope={scope}
+      />
+      <div className="md:flex w-full min-h-screen flex-1 overflow-y-auto">
+        {/* Sidebar document list for desktop */}
+        <aside className="hidden md:block w-[220px] shrink-0 border-r overflow-y-auto">
+          <div className="flex flex-col h-full">
             <DocumentList basketId={basketId} />
+            <div className="p-4 border-t">
+              <Button size="sm" disabled className="w-full">
+                + Create Document
+              </Button>
+            </div>
+          </div>
+        </aside>
+        {/* Main dashboard content */}
+        <div className="flex-1 p-4 space-y-6">
+          {/* Mobile document list */}
+          <section className="md:hidden">
+            <h2 className="font-medium mb-2">Documents</h2>
+            <Card className="p-4">
+              <DocumentList basketId={basketId} />
             <div className="pt-4">
               <Button size="sm" disabled className="w-full">
                 + Create Document
@@ -64,6 +81,7 @@ export default function BasketDashboardLayout({ basketId, dumpBody }: Props) {
             {dumpBody ? dumpBody : "No dumps yet."}
           </Card>
         </section>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- rename `BasketHeader` to `BasketSidebarHeader`
- add new `BasketSidebar` component
- expand `BasketDashboardLayout` with sidebar support
- update basket work page to pass sidebar props

## Testing
- `make lint` *(fails: Found 158 errors)*
- `make format` *(fails: black: command not found)*
- `make tests` *(fails: 24 failed, 29 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6875dff9dfb48329aadc38e0ddf09f6e