### PR TITLE
Finalize dedicated layout for basket workspace

### DIFF
--- a/web/app/baskets/[id]/work/layout.tsx
+++ b/web/app/baskets/[id]/work/layout.tsx
@@ -1,0 +1,5 @@
+import BasketDashboardLayout from "@/components/layouts/BasketDashboardLayout";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <BasketDashboardLayout>{children}</BasketDashboardLayout>;
+}

--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -1,13 +1,13 @@
-import BasketDashboardLayout from "@/components/layouts/BasketDashboardLayout"
-import { createServerSupabaseClient } from "@/lib/supabaseServerClient"
-import { redirect } from "next/navigation"
+import BasketDashboardLayout from "@/components/layouts/BasketDashboardLayout";
+import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
+import { redirect } from "next/navigation";
 
 export default async function BasketWorkPage({
   params,
 }: {
-  params: Promise<{ id: string }>
+  params: { id: string };
 }) {
-  const { id } = await params
+  const { id } = params;
 
   const supabase = createServerSupabaseClient()
 
@@ -15,10 +15,8 @@ export default async function BasketWorkPage({
     data: { session },
   } = await supabase.auth.getSession()
 
-  console.log("🔐 Supabase session:", session)
-
   if (!session) {
-    redirect("/login")
+    redirect("/login");
   }
 
   const { data: basket, error: basketError } = await supabase
@@ -26,10 +24,6 @@ export default async function BasketWorkPage({
     .select("id, name, state, tags")
     .eq("id", id)
     .single()
-
-  console.log("🧺 Basket ID param:", id)
-  console.log("📰 Supabase basket query result:", basket)
-  console.log("❗ Supabase basket query error:", basketError)
 
   if (!basket) {
     // Disable redirect to inspect error first


### PR DESCRIPTION
## Summary
- clean up `BasketWorkPage` server component
- add local layout for `/baskets/[id]/work` to host workspace subroutes

## Testing
- `make lint` *(fails: unused imports in repo)*
- `make format` *(fails: pyenv missing Python 3.11.9)*
- `make tests` *(fails: several failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6876157b7678832993accbe62afb491f