### PR TITLE
feat: dynamic oauth redirect with path restore

### DIFF
--- a/web/app/auth/callback/page.tsx
+++ b/web/app/auth/callback/page.tsx
@@ -17,15 +17,27 @@ export default function AuthCallbackPage() {
         setTimeout(() => router.replace("/login"), 1500);
         return;
       }
+
+      const storedPath =
+        typeof window !== "undefined"
+          ? localStorage.getItem("postLoginPath")
+          : null;
+
+      if (storedPath) {
+        localStorage.removeItem("postLoginPath");
+        router.replace(storedPath);
+        return;
+      }
+
       const { data: baskets } = await supabase
-        .from('baskets')
-        .select('id')
-        .eq('user_id', data.session.user.id)
+        .from("baskets")
+        .select("id")
+        .eq("user_id", data.session.user.id)
         .limit(1);
       if (!baskets || baskets.length === 0) {
-        router.replace('/baskets/new');
+        router.replace("/baskets/new");
       } else {
-        router.replace('/dashboard');
+        router.replace("/dashboard");
       }
     };
     checkSession();

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -24,11 +24,14 @@ export default function LoginPage() {
 
   // Google OAuth
   const handleGoogleLogin = async () => {
-    const redirectTo = `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`;
+    // Preserve the current path so we can restore it after OAuth
+    if (typeof window !== "undefined") {
+      localStorage.setItem("postLoginPath", window.location.pathname);
+    }
     const { error } = await supabase.auth.signInWithOAuth({
       provider: "google",
       options: {
-        redirectTo,
+        redirectTo: `${window.location.origin}/auth/callback`,
         queryParams: { prompt: "select_account" },
       },
     });
@@ -39,11 +42,14 @@ export default function LoginPage() {
 
   // Dev-only Magic Link Login
   const handleMagicLinkLogin = async () => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("postLoginPath", window.location.pathname);
+    }
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {
         shouldCreateUser: false,
-        emailRedirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`,
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
       },
     });
     if (error) {


### PR DESCRIPTION
## Summary
- preserve path before OAuth login
- use dynamic window origin for callback URL
- restore preserved path on `/auth/callback`

## Testing
- `make lint` *(fails: 158 errors)*
- `make format` *(fails: pyenv version error)*
- `make tests` *(fails: 24 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_687728a461188329a9e902d3e44eba74