### PR TITLE
Simplify /home page logic

### DIFF
--- a/web/app/home/page.tsx
+++ b/web/app/home/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { useEffect, useState } from "react";
 
 export default function HomePage() {
-  const router = useRouter();
   const supabase = createClientComponentClient();
+  const [loading, setLoading] = useState(true);
+  const [userEmail, setUserEmail] = useState<string | null>(null);
 
   useEffect(() => {
     const run = async () => {
@@ -14,45 +14,28 @@ export default function HomePage() {
         data: { user },
         error,
       } = await supabase.auth.getUser();
-
       if (error || !user) {
         console.warn("❌ No user. Redirecting to /login.");
-        router.replace("/login");
+        window.location.href = "/login";
         return;
       }
 
-      const { data: workspace, error: wsError } = await supabase
-        .from("workspaces")
-        .select("id")
-        .eq("owner_id", user.id)
-        .single();
-
-      if (wsError || !workspace) {
-        console.warn("⚠️ No workspace. Redirecting to /baskets/new.");
-        router.replace("/baskets/new");
-        return;
-      }
-
-      const { data: basket } = await supabase
-        .from("baskets")
-        .select("id")
-        .eq("workspace_id", workspace.id)
-        .order("created_at", { ascending: true })
-        .limit(1)
-        .maybeSingle();
-
-      const redirectTarget = basket?.id
-        ? `/baskets/${basket.id}/work`
-        : "/baskets/new";
-
-      console.log("🧭 [HOME] Redirecting to:", redirectTarget);
-      router.replace(redirectTarget);
+      setUserEmail(user.email);
+      setLoading(false);
     };
 
     run();
   }, []);
 
+  if (loading) return <p className="p-4 text-muted-foreground">Loading...</p>;
+
   return (
-    <p className="p-4 text-muted-foreground">Preparing your workspace...</p>
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">👋 Welcome back</h1>
+      <p className="text-muted-foreground">
+        You are logged in as <strong>{userEmail}</strong>
+      </p>
+      <p className="mt-4">Use the left sidebar to select or create a basket.</p>
+    </div>
   );
 }

--- a/web/app/work/page.tsx
+++ b/web/app/work/page.tsx
@@ -6,7 +6,7 @@ export default function OrphanWorkRedirect() {
   const router = useRouter();
 
   useEffect(() => {
-    console.warn("🚨 Invalid /work route accessed. Redirecting to /home.");
+    console.warn("🚨 Invalid /work route. Redirecting to /home.");
     router.replace("/home");
   }, []);
 


### PR DESCRIPTION
## Summary
- render `/home` as a simple dashboard instead of redirecting
- keep `/work` safety redirect in place

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878b210761083298a37fe14a1bfd19d