### PR TITLE
Refactor Sidebar responsive behavior

### DIFF
--- a/web/app/components/shell/Sidebar.tsx
+++ b/web/app/components/shell/Sidebar.tsx
@@ -70,9 +70,14 @@ export default function Sidebar({ className }: SidebarProps) {
 
   return (
     <aside
-      className={`sidebar fixed top-0 left-0 z-40 h-screen w-64 bg-background border-r border-border shadow-md transition-all duration-300 ${
-        isOpen ? "translate-x-0" : "-translate-x-full"
-      } ${collapsible ? "md:relative md:translate-x-0" : ""} ${className ?? ""}`}
+      className={cn(
+        "sidebar h-screen w-64 bg-background border-r border-border transition-transform duration-300",
+        collapsible
+          ? "fixed top-0 left-0 z-40 shadow-md md:relative md:translate-x-0"
+          : "relative",
+        isOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0",
+        className
+      )}
     >
       <div className="sticky top-0 z-10 border-b bg-background px-4 py-3 flex items-center justify-between">
         <button onClick={handleBrandClick} className="font-brand text-xl tracking-tight hover:underline">

--- a/web/components/layout/Shell.tsx
+++ b/web/components/layout/Shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect } from "react";
-import Sidebar from "@/app/components/layout/Sidebar";
+import Sidebar from "@/app/components/shell/Sidebar";
 import TopBar from "@/components/common/TopBar";
 import { useSidebarStore } from "@/lib/stores/sidebarStore";
 import { usePathname } from "next/navigation";
@@ -9,7 +9,7 @@ import { FileDropOverlay } from "@/components/FileDropOverlay";
 
 export default function Shell({ children }: { children: React.ReactNode }) {
     const pathname = usePathname();
-    const { openSidebar, closeSidebar, setCollapsible } = useSidebarStore();
+    const { openSidebar, closeSidebar, setCollapsible, isOpen } = useSidebarStore();
     const { isDraggingFile } = useFileDrag();
 
     useEffect(() => {
@@ -30,18 +30,24 @@ export default function Shell({ children }: { children: React.ReactNode }) {
 
     return (
         <div
-            className="flex h-screen overflow-hidden"
+            className="flex h-screen"
             onDrop={noopDropHandler}
             onDragOver={(e) => e.preventDefault()}
         >
             <FileDropOverlay isVisible={isDraggingFile} />
             <Sidebar />
-            <div className="flex flex-1 flex-col">
+            <div className="flex flex-1 flex-col overflow-hidden">
                 <TopBar />
                 <main className="flex-1 overflow-y-auto px-4 pt-16 md:pt-8 md:px-8">
                     {children}
                 </main>
             </div>
+            {isOpen && (
+                <div
+                    className="fixed inset-0 bg-black/30 z-30 md:hidden"
+                    onClick={closeSidebar}
+                />
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- move `Sidebar` to `app/components/shell`
- make sidebar fixed on mobile and relative on desktop
- update `Shell` layout to use flex screen container and overlay backdrop

## Testing
- `pre-commit` *(fails: command not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879cfc110d08329bbc523b67a2b1e8b