### PR TITLE
Use authenticated workspace for manager plan

### DIFF
--- a/api/INTEGRATION_COMPLETE.md
+++ b/api/INTEGRATION_COMPLETE.md
@@ -46,7 +46,7 @@ TasksDocumentComposerAgent:
 
 ### Manager Service Rewritten
 ```python
-async def run_manager_plan(db, req: BasketChangeRequest) -> PlanResult:
+async def run_manager_plan(db, req: BasketChangeRequest, workspace_id: str) -> PlanResult:
     # STEP 1: Call real worker agents
     analyzer_output = await WorkerAgentAdapter.call_basket_analyzer(...)
     composer_output = await WorkerAgentAdapter.call_document_composer(...)

--- a/api/src/app/routes/baskets.py
+++ b/api/src/app/routes/baskets.py
@@ -1,59 +1,73 @@
 import json
-import sys
 import os
+import sys
 
 # CRITICAL: Add src to path BEFORE any other imports that depend on it
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
 
-from fastapi import APIRouter, HTTPException, Depends
 from contracts.basket import BasketChangeRequest, BasketDelta
+from fastapi import APIRouter, Depends, HTTPException
+from services.deltas import list_deltas, persist_delta, try_apply_delta
 from services.idempotency import (
     already_processed,
-    mark_processed,
     fetch_delta_by_request_id,
+    mark_processed,
 )
 from services.manager import run_manager_plan
-from services.deltas import persist_delta, list_deltas, try_apply_delta
-from repositories.delta_repository import DeltaRepository
-from repositories.event_repository import EventRepository
 
 # Import deps AFTER path setup
 from ..deps import get_db
+from ..utils.jwt import verify_jwt
+from ..utils.workspace import get_or_create_workspace
 
 router = APIRouter(prefix="/api/baskets", tags=["baskets"])
 
+
 @router.post("/{basket_id}/work", response_model=BasketDelta)
-async def post_basket_work(basket_id: str, req: BasketChangeRequest, db=Depends(get_db)):
+async def post_basket_work(
+    basket_id: str,
+    req: BasketChangeRequest,
+    user: dict = Depends(verify_jwt),  # noqa: B008
+    db=Depends(get_db),  # noqa: B008
+):
     """Process basket work request"""
     if req.basket_id != basket_id:
         raise HTTPException(400, "basket_id mismatch")
-    
+
+    workspace_id = get_or_create_workspace(user["user_id"])
+
     # Check idempotency
     if await already_processed(db, req.request_id):
         cached_delta = await fetch_delta_by_request_id(db, req.request_id)
         if not cached_delta:
             raise HTTPException(409, "Duplicate request but missing delta")
         return BasketDelta(**json.loads(cached_delta["payload"]))
-    
+
     # Run manager plan - now returns BasketDelta directly
-    delta = await run_manager_plan(db, req)
-    
+    delta = await run_manager_plan(db, req, workspace_id)
+
     # Persist with event publishing
     await persist_delta(db, delta, req.request_id)
     await mark_processed(db, req.request_id, delta.delta_id)
-    
+
     return delta
 
+
 @router.get("/{basket_id}/deltas")
-async def get_basket_deltas(basket_id: str, db=Depends(get_db)):
+async def get_basket_deltas(basket_id: str, db=Depends(get_db)):  # noqa: B008
     """Get all deltas for a basket"""
     return await list_deltas(db, basket_id)
 
+
 @router.post("/{basket_id}/apply/{delta_id}")
-async def apply_basket_delta(basket_id: str, delta_id: str, db=Depends(get_db)):
+async def apply_basket_delta(
+    basket_id: str,
+    delta_id: str,
+    db=Depends(get_db),  # noqa: B008
+):
     """Apply a specific delta"""
     success = await try_apply_delta(db, basket_id, delta_id)
     if not success:
         raise HTTPException(409, "Version conflict or delta not found")
-    
+
     return {"status": "applied", "basket_id": basket_id, "delta_id": delta_id}

--- a/api/src/services/manager.py
+++ b/api/src/services/manager.py
@@ -1,74 +1,87 @@
-import sys
 import os
+import sys
 from uuid import uuid4
-from typing import List
 
 # Add src to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from contracts.basket import BasketChangeRequest, BasketDelta, EntityChangeBlock
+from contracts.basket import BasketChangeRequest, BasketDelta
 from services.clock import now_iso
 from services.worker_adapter import WorkerAgentAdapter, WorkerOutputAggregator
 
-async def run_manager_plan(db, req: BasketChangeRequest) -> BasketDelta:
+
+async def run_manager_plan(
+    db, req: BasketChangeRequest, workspace_id: str
+) -> BasketDelta:
     """
     REAL Manager Agent Orchestration - No more fake data!
-    
+
     This coordinates actual worker agents and aggregates their real analysis.
     """
-    
+
     try:
-        # Extract workspace_id from database or context (simplified for now)
-        workspace_id = "default-workspace"  # TODO: Extract from auth context
-        
         print(f"🤖 Manager orchestrating workers for basket {req.basket_id}")
-        
+
         # STEP 1: Call real worker agents in parallel
         worker_outputs = []
-        
+
         # Call InfraBasketAnalyzerAgent
         print("  📊 Calling InfraBasketAnalyzerAgent...")
         analyzer_output = await WorkerAgentAdapter.call_basket_analyzer(
             basket_id=req.basket_id,
             workspace_id=workspace_id,
             sources=req.sources or [],
-            context=req.user_context
+            context=req.user_context,
         )
         worker_outputs.append(analyzer_output)
-        print(f"    ✓ Analysis complete: {len(analyzer_output.changes)} changes, confidence: {analyzer_output.confidence}")
-        
-        # Call TasksDocumentComposerAgent  
+        print(
+            "    ✓ Analysis complete: "
+            f"{len(analyzer_output.changes)} changes, confidence: {analyzer_output.confidence}"
+        )
+
+        # Call TasksDocumentComposerAgent
         print("  📝 Calling TasksDocumentComposerAgent...")
         composer_output = await WorkerAgentAdapter.call_document_composer(
             basket_id=req.basket_id,
             workspace_id=workspace_id,
-            analysis_result=analyzer_output
+            analysis_result=analyzer_output,
         )
         worker_outputs.append(composer_output)
-        print(f"    ✓ Composition complete: {len(composer_output.changes)} changes, confidence: {composer_output.confidence}")
-        
+        print(
+            "    ✓ Composition complete: "
+            f"{len(composer_output.changes)} changes, confidence: {composer_output.confidence}"
+        )
+
         # STEP 2: Aggregate worker outputs
         print("  🔄 Aggregating worker outputs...")
         aggregated = WorkerOutputAggregator.aggregate_outputs(worker_outputs)
-        
+
         # STEP 3: Manager-level analysis and conflict resolution
         print("  🧠 Manager analyzing aggregated results...")
-        
+
         # Add manager's own analysis
         manager_explanation = {
-            "by": "manager", 
-            "text": f"Orchestrated {len(worker_outputs)} agents: {', '.join(w.agent_name for w in worker_outputs)}"
+            "by": "manager",
+            "text": (
+                "Orchestrated "
+                f"{len(worker_outputs)} agents: {', '.join(w.agent_name for w in worker_outputs)}"
+            ),
         }
         aggregated["explanations"].append(manager_explanation)
-        
+
         # Apply manager-level conflict resolution if needed
         final_changes = resolve_change_conflicts(aggregated["changes"])
-        
+
         # Calculate final confidence with manager adjustment
-        final_confidence = min(aggregated["confidence"] * 0.9, 1.0)  # Slight manager conservatism
-        
-        print(f"  ✅ Manager plan complete: {len(final_changes)} final changes, confidence: {final_confidence}")
-        
+        final_confidence = min(
+            aggregated["confidence"] * 0.9, 1.0
+        )  # Slight manager conservatism
+
+        print(
+            "  ✅ Manager plan complete: "
+            f"{len(final_changes)} final changes, confidence: {final_confidence}"
+        )
+
         return BasketDelta(
             delta_id=str(uuid4()),
             basket_id=req.basket_id,
@@ -77,12 +90,12 @@ async def run_manager_plan(db, req: BasketChangeRequest) -> BasketDelta:
             recommended_actions=aggregated.get("recommended_actions", []),
             explanations=aggregated.get("explanations", []),
             confidence=final_confidence,
-            created_at=now_iso()
+            created_at=now_iso(),
         )
-        
+
     except Exception as e:
         print(f"  ❌ Manager orchestration failed: {e}")
-        
+
         # Fallback to error delta
         return BasketDelta(
             delta_id=str(uuid4()),
@@ -92,33 +105,33 @@ async def run_manager_plan(db, req: BasketChangeRequest) -> BasketDelta:
             recommended_actions=[],
             explanations=[{"by": "manager", "text": str(e)}],
             confidence=0.0,
-            created_at=now_iso()
+            created_at=now_iso(),
         )
 
 
-def resolve_change_conflicts(changes: List) -> List:
+def resolve_change_conflicts(changes: list) -> list:
     """
     Manager-level conflict resolution for worker agent changes.
-    
+
     This is where the Manager Agent adds value beyond individual workers.
     """
-    
+
     # Simple conflict resolution for now
     # TODO: Implement sophisticated conflict detection and resolution
-    
+
     # Remove duplicate changes (same entity + id)
     seen_changes = set()
     resolved_changes = []
-    
+
     for change in changes:
         change_key = (change.entity, change.id)
         if change_key not in seen_changes:
             seen_changes.add(change_key)
             resolved_changes.append(change)
-    
+
     # TODO: Add more sophisticated conflict resolution:
     # - Version conflicts (same entity, different versions)
     # - Logical conflicts (incompatible changes)
     # - Priority-based resolution (trust certain agents more)
-    
+
     return resolved_changes

--- a/api/test_end_to_end.py
+++ b/api/test_end_to_end.py
@@ -5,7 +5,6 @@ Verifies the complete integration without fake data.
 """
 
 import asyncio
-import json
 import sys
 from pathlib import Path
 from uuid import uuid4
@@ -13,228 +12,253 @@ from uuid import uuid4
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent / "src"))
 
+
 async def test_manager_worker_integration():
     """Test the real manager → worker integration."""
     print("🤖 Testing Manager Agent → Worker Integration...")
-    
+
     try:
-        from services.manager import run_manager_plan, PlanResult
         from contracts.basket import BasketChangeRequest, SourceText
-        
+        from services.manager import run_manager_plan
+
         # Create a realistic test request
         test_request = BasketChangeRequest(
             request_id=f"test-{uuid4()}",
             basket_id="test-basket-123",
             intent="analyze and compose",
             sources=[
-                SourceText(type="text", content="Create a project plan for building a web application"),
-                SourceText(type="text", content="Include authentication, database design, and API endpoints")
+                SourceText(
+                    type="text",
+                    content="Create a project plan for building a web application",
+                ),
+                SourceText(
+                    type="text",
+                    content="Include authentication, database design, and API endpoints",
+                ),
             ],
-            user_context={"user_goal": "MVP development"}
+            user_context={"user_goal": "MVP development"},
         )
-        
+
         print(f"  📝 Created test request: {test_request.request_id}")
-        
+
         # Run the real manager orchestration
-        result = await run_manager_plan(None, test_request)  # db=None for this test
-        
-        print(f"  ✅ Manager plan completed:")
+        result = await run_manager_plan(
+            None, test_request, "test-workspace"
+        )  # db=None for this test
+
+        print("  ✅ Manager plan completed:")
         print(f"    Delta ID: {result.delta_id}")
         print(f"    Summary: {result.summary}")
         print(f"    Changes: {len(result.changes)}")
         print(f"    Explanations: {len(result.explanations)}")
         print(f"    Confidence: {result.confidence}")
         print(f"    Recommended Actions: {len(result.recommended_actions)}")
-        
+
         # Verify we got real data, not fake placeholders
         assert result.delta_id != "fake"
         assert len(result.explanations) >= 2  # At least manager + 1 worker
-        assert any("manager" in exp.get("by", "").lower() for exp in result.explanations)
+        assert any(
+            "manager" in exp.get("by", "").lower() for exp in result.explanations
+        )
         assert result.confidence > 0
-        
+
         print("  🎉 Integration test PASSED - No fake data detected!")
         return True
-        
+
     except Exception as e:
         print(f"  ❌ Integration test FAILED: {e}")
         return False
 
+
 async def test_database_operations():
     """Test database operations for Manager Agent system."""
     print("\n💾 Testing Database Operations...")
-    
+
     try:
-        from services.idempotency import already_processed, mark_processed
-        from services.deltas import persist_delta
-        from services.events import publish_event
+        # Skip database tests if no DATABASE_URL
+        import os
+
         from contracts.basket import BasketDelta
         from services.clock import now_iso
-        
-        # Skip database tests if no DATABASE_URL 
-        import os
+        from services.deltas import persist_delta
+        from services.events import publish_event
+        from services.idempotency import already_processed, mark_processed
+
         if not os.getenv("DATABASE_URL"):
             print("  ⚠️  Skipping database tests - DATABASE_URL not set")
             return True
-        
+
         from src.app.deps import get_db
+
         db = await get_db()
-        
+
         # Test idempotency
         test_request_id = f"test-req-{uuid4()}"
         is_processed = await already_processed(db, test_request_id)
         print(f"  ✓ Idempotency check: {is_processed}")
-        assert is_processed == False
-        
+        assert not is_processed
+
         # Test delta persistence
         test_delta = BasketDelta(
             delta_id=f"test-delta-{uuid4()}",
             basket_id="test-basket",
             summary="Test delta for integration",
             changes=[],
-            created_at=now_iso()
+            created_at=now_iso(),
         )
-        
+
         await persist_delta(db, test_delta, test_request_id)
         print(f"  ✓ Delta persisted: {test_delta.delta_id}")
-        
+
         # Test idempotency marking
         await mark_processed(db, test_request_id, test_delta.delta_id)
         print(f"  ✓ Request marked processed: {test_request_id}")
-        
+
         # Verify idempotency works
         is_processed_now = await already_processed(db, test_request_id)
-        assert is_processed_now == True
+        assert is_processed_now
         print(f"  ✓ Idempotency verified: {is_processed_now}")
-        
+
         # Test event publishing
-        await publish_event(db, "test.integration", {
-            "basket_id": "test-basket",
-            "delta_id": test_delta.delta_id,
-            "test": True
-        })
-        print(f"  ✓ Event published successfully")
-        
+        await publish_event(
+            db,
+            "test.integration",
+            {"basket_id": "test-basket", "delta_id": test_delta.delta_id, "test": True},
+        )
+        print("  ✓ Event published successfully")
+
         print("  🎉 Database operations test PASSED!")
         return True
-        
+
     except Exception as e:
         print(f"  ❌ Database operations test FAILED: {e}")
         return False
 
+
 async def test_worker_adapter():
     """Test the WorkerAgentAdapter directly."""
     print("\n🔧 Testing WorkerAgentAdapter...")
-    
+
     try:
         from services.worker_adapter import WorkerAgentAdapter, WorkerOutputAggregator
-        
-        # Test basket analyzer adapter (will likely fail due to missing deps, but should handle gracefully)
+
+        # Test basket analyzer adapter (will likely fail due to missing deps,
+        # but should handle gracefully)
         analyzer_output = await WorkerAgentAdapter.call_basket_analyzer(
             basket_id="test-basket-123",
             workspace_id="test-workspace",
             sources=[{"type": "text", "content": "test"}],
-            context={}
+            context={},
         )
-        
+
         print(f"  ✓ Analyzer adapter returned: {analyzer_output.agent_name}")
         print(f"    Changes: {len(analyzer_output.changes)}")
         print(f"    Confidence: {analyzer_output.confidence}")
         print(f"    Explanation: {analyzer_output.explanation[:100]}...")
-        
+
         # Test document composer adapter
         composer_output = await WorkerAgentAdapter.call_document_composer(
-            basket_id="test-basket-123", 
-            workspace_id="test-workspace"
+            basket_id="test-basket-123", workspace_id="test-workspace"
         )
-        
+
         print(f"  ✓ Composer adapter returned: {composer_output.agent_name}")
         print(f"    Changes: {len(composer_output.changes)}")
         print(f"    Confidence: {composer_output.confidence}")
-        
+
         # Test aggregation
-        aggregated = WorkerOutputAggregator.aggregate_outputs([analyzer_output, composer_output])
-        
-        print(f"  ✓ Aggregation complete:")
+        aggregated = WorkerOutputAggregator.aggregate_outputs(
+            [analyzer_output, composer_output]
+        )
+
+        print("  ✓ Aggregation complete:")
         print(f"    Total changes: {len(aggregated['changes'])}")
         print(f"    Overall confidence: {aggregated['confidence']}")
         print(f"    Explanations: {len(aggregated['explanations'])}")
-        
+
         print("  🎉 WorkerAgentAdapter test PASSED!")
         return True
-        
+
     except Exception as e:
         print(f"  ❌ WorkerAgentAdapter test FAILED: {e}")
         return False
 
+
 async def test_api_endpoint():
     """Test the full API endpoint if possible."""
     print("\n🌐 Testing API Endpoint...")
-    
+
     try:
         import httpx
-        
+
         # Try to test against local server
         test_payload = {
             "request_id": f"test-api-{uuid4()}",
             "basket_id": "test-basket-api",
             "intent": "test api endpoint",
-            "sources": [{"type": "text", "content": "test content"}]
+            "sources": [{"type": "text", "content": "test content"}],
         }
-        
+
         # This will likely fail without a running server, but that's expected
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.post(
                     "http://localhost:8000/api/baskets/test-basket-api/work",
                     json=test_payload,
-                    timeout=5.0
+                    timeout=5.0,
                 )
-                
+
                 if response.status_code == 200:
                     result = response.json()
-                    print(f"  ✓ API endpoint success: {result.get('summary', 'No summary')}")
+                    print(
+                        f"  ✓ API endpoint success: {result.get('summary', 'No summary')}"
+                    )
                 elif response.status_code in [401, 403]:
-                    print(f"  ✓ API endpoint responds (auth required): {response.status_code}")
+                    print(
+                        f"  ✓ API endpoint responds (auth required): {response.status_code}"
+                    )
                 else:
                     print(f"  ⚠️  API endpoint returned: {response.status_code}")
-                    
+
             except httpx.ConnectError:
-                print("  ℹ️  API server not running - this is expected for deployment test")
+                print(
+                    "  ℹ️  API server not running - this is expected for deployment test"
+                )
             except Exception as e:
                 print(f"  ℹ️  API test skipped: {e}")
-        
+
         return True
-        
+
     except ImportError:
         print("  ℹ️  httpx not available - skipping API test")
         return True
+
 
 async def main():
     """Run all integration tests."""
     print("🚀 End-to-End Integration Test")
     print("Testing Real Manager Agent → Workers → Database → Events")
     print("=" * 60)
-    
+
     results = []
-    
+
     # Run tests
     results.append(await test_manager_worker_integration())
-    results.append(await test_worker_adapter()) 
+    results.append(await test_worker_adapter())
     results.append(await test_database_operations())
     results.append(await test_api_endpoint())
-    
+
     print("=" * 60)
-    
+
     # Summary
     passed = sum(results)
     total = len(results)
-    
+
     if passed == total:
         print(f"🎉 ALL INTEGRATION TESTS PASSED ({passed}/{total})")
         print("✅ Manager Agent System is FULLY INTEGRATED!")
         print("\n🔗 Complete Flow Verified:")
         print("  1. ✅ Manager orchestrates real workers")
-        print("  2. ✅ Workers return structured analysis") 
+        print("  2. ✅ Workers return structured analysis")
         print("  3. ✅ Outputs aggregated and normalized")
         print("  4. ✅ Database operations work")
         print("  5. ✅ Events published for frontend")
@@ -244,6 +268,7 @@ async def main():
         print(f"❌ SOME TESTS FAILED ({passed}/{total})")
         print("🔧 Check errors above - integration may have issues")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- pass workspace ID from authenticated user when orchestrating manager plan
- expose workspace lookup in basket work route and update end-to-end test
- document updated `run_manager_plan` signature

## Testing
- `uv run black api/src/services/manager.py api/src/app/routes/baskets.py api/test_end_to_end.py`
- `uv run ruff check api/src/app/routes/baskets.py api/src/services/manager.py api/test_end_to_end.py`
- `uv run mypy api/src/services/manager.py api/src/app/routes/baskets.py api/test_end_to_end.py` *(fails: Cannot find implementation or library stub for module named "contracts.basket" and others)*
- `uv run pytest api/test_end_to_end.py`


------
https://chatgpt.com/codex/tasks/task_e_689bf16eef2c83299ef1cd51bdef8c99