### PR TITLE
feat: restructure create page with capture and preview panels

### DIFF
--- a/web/app/create/page.tsx
+++ b/web/app/create/page.tsx
@@ -1,59 +1,49 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { MemoryCapture, SourceInput } from './components/MemoryCapture';
-import { apiClient } from '@/lib/api/client';
+import { CaptureTray } from "@/components/create/CaptureTray";
+import { PreviewPanel } from "@/components/create/PreviewPanel";
+import { useCreatePageMachine } from "@/components/create/useCreatePageMachine";
 
 export default function CreatePage() {
-  const router = useRouter();
-  const [basketId, setBasketId] = useState<string | null>(null);
-
-  const handleMemoryFormation = async (intent: string, inputs: SourceInput[]) => {
-    try {
-      // 1. Create basket with correct endpoint
-      const basket = await apiClient.request<{ id: string }>('/api/baskets', {
-        method: 'POST',
-        body: JSON.stringify({ 
-          name: intent || 'New Basket',
-          description: intent,
-          status: 'INIT' 
-        }),
-      });
-
-      // 2. Set basket ID for loading UI
-      setBasketId(basket.id);
-
-      // 3. Create raw dumps using the correct dump API
-      if (inputs.length > 0) {
-        await Promise.all(
-          inputs.map((input) =>
-            apiClient.request('/api/dumps/new', {
-              method: 'POST',
-              body: JSON.stringify({
-                basket_id: basket.id,
-                text_dump: input.content || `File: ${input.name}`,
-                file_urls: input.type === 'file' ? [input.id] : []
-              }),
-            })
-          )
-        );
-      }
-
-      // 4. Redirect immediately to work page (remove delay)
-      router.push(`/baskets/${basket.id}/work`);
-      
-    } catch (error) {
-      console.error('❌ Basket creation failed:', error);
-      // Reset loading state on error
-      setBasketId(null);
-      alert('Failed to create basket. Please try again.');
-    }
-  };
+  const machine = useCreatePageMachine();
 
   return (
     <div className="container py-8">
-      <MemoryCapture onFormation={handleMemoryFormation} basketId={basketId} />
+      <div className="md:grid md:grid-cols-2 md:gap-6">
+        <CaptureTray
+          intent={machine.intent}
+          items={machine.items}
+          onIntent={machine.setIntent}
+          addFiles={machine.addFiles}
+          addUrl={machine.addUrl}
+          addNote={machine.addNote}
+          removeItem={machine.removeItem}
+          clearAll={machine.clearAll}
+          generate={machine.generate}
+        />
+        <div className="hidden md:block">
+          <PreviewPanel
+            intent={machine.intent}
+            items={machine.items}
+            state={machine.state}
+            progress={machine.progress}
+          />
+        </div>
+      </div>
+
+      <div className="md:hidden mt-8">
+        <details>
+          <summary className="cursor-pointer">Preview</summary>
+          <PreviewPanel
+            intent={machine.intent}
+            items={machine.items}
+            state={machine.state}
+            progress={machine.progress}
+          />
+        </details>
+      </div>
+
+      <div className="text-xs text-gray-500 mt-4">State: {machine.state}</div>
     </div>
   );
 }

--- a/web/components/create/AddedItemRow.tsx
+++ b/web/components/create/AddedItemRow.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { AddedItem } from './useCreatePageMachine';
+
+interface Props {
+  item: AddedItem;
+  onRemove: (id: string) => void;
+}
+
+export function AddedItemRow({ item, onRemove }: Props) {
+  const icon = item.kind === 'file' ? '🗎' : item.kind === 'url' ? '🔗' : '📝';
+  const size = item.size ? `${(item.size / 1024 / 1024).toFixed(1)}MB` : '';
+  const label =
+    item.kind === 'file'
+      ? item.name
+      : item.kind === 'url'
+      ? item.url
+      : item.text?.slice(0, 30) + (item.text && item.text.length > 30 ? '…' : '');
+
+  return (
+    <div className="flex items-center justify-between text-sm py-1 border-b last:border-b-0">
+      <div className="flex items-center gap-2 min-w-0">
+        <span>{icon}</span>
+        <span className="truncate">{label}</span>
+        {size && <span className="text-xs text-gray-500">{size}</span>}
+        <button
+          className="text-xs text-blue-500 hover:underline ml-2"
+          onClick={() => onRemove(item.id)}
+        >
+          Remove
+        </button>
+      </div>
+      <div className="text-xs text-gray-500">{item.status}</div>
+    </div>
+  );
+}
+

--- a/web/components/create/CaptureTray.tsx
+++ b/web/components/create/CaptureTray.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useDropzone } from 'react-dropzone';
+import { IntentField } from '@/app/create/components/IntentField';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Textarea } from '@/components/ui/Textarea';
+import { AddedItem } from './useCreatePageMachine';
+import { AddedItemRow } from './AddedItemRow';
+
+interface Props {
+  intent: string;
+  items: AddedItem[];
+  onIntent: (v: string) => void;
+  addFiles: (files: File[]) => void;
+  addUrl: (url: string) => void;
+  addNote: (text: string) => void;
+  removeItem: (id: string) => void;
+  clearAll: () => void;
+  generate: () => void;
+}
+
+export function CaptureTray({
+  intent,
+  items,
+  onIntent,
+  addFiles,
+  addUrl,
+  addNote,
+  removeItem,
+  clearAll,
+  generate,
+}: Props) {
+  const urlRef = useRef<HTMLInputElement>(null);
+  const [note, setNote] = useState('');
+
+  const onDrop = useCallback(
+    (accepted: File[]) => {
+      addFiles(accepted);
+    },
+    [addFiles]
+  );
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop, multiple: true });
+
+  useEffect(() => {
+    const onPaste = (e: ClipboardEvent) => {
+      const files: File[] = [];
+      for (const item of e.clipboardData?.items ?? []) {
+        if (item.kind === 'file') {
+          const f = item.getAsFile();
+          if (f) files.push(f);
+        }
+      }
+      if (files.length) {
+        addFiles(files);
+      } else {
+        const text = e.clipboardData?.getData('text')?.trim();
+        if (text) {
+          try {
+            const u = new URL(text);
+            addUrl(u.toString());
+          } catch {
+            addNote(text);
+          }
+        }
+      }
+    };
+    window.addEventListener('paste', onPaste);
+    return () => window.removeEventListener('paste', onPaste);
+  }, [addFiles, addUrl, addNote]);
+
+  const handleAddUrl = () => {
+    const v = urlRef.current?.value?.trim();
+    if (!v) return;
+    try {
+      const u = new URL(v);
+      addUrl(u.toString());
+      if (urlRef.current) urlRef.current.value = '';
+    } catch {
+      /* noop */
+    }
+  };
+
+  const handleAddNote = () => {
+    if (!note.trim()) return;
+    addNote(note.trim());
+    setNote('');
+  };
+
+  const counts = {
+    file: items.filter((i) => i.kind === 'file').length,
+    url: items.filter((i) => i.kind === 'url').length,
+    note: items.filter((i) => i.kind === 'note').length,
+  };
+
+  const total = items.length;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <IntentField value={intent} onChange={onIntent} />
+        <p className="text-sm text-gray-500 mt-1">
+          Drop files, links, or notes. We’ll organize them into a starter basket.
+        </p>
+      </div>
+
+      <div {...getRootProps()} className={`rounded border-2 border-dashed p-6 text-center ${isDragActive ? 'opacity-100' : 'opacity-80'}`}>
+        <input {...getInputProps()} />
+        <div>Drop files here, or paste text/screenshots anywhere</div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Input ref={urlRef} placeholder="Paste a link" onKeyDown={(e) => e.key === 'Enter' && handleAddUrl()} />
+        <Button onClick={handleAddUrl}>Add link</Button>
+      </div>
+
+      <div className="flex items-start gap-2">
+        <Textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="Write a note"
+          className="h-24"
+        />
+        <Button onClick={handleAddNote}>Add note</Button>
+      </div>
+
+      {total > 0 && (
+        <div className="border rounded p-2">
+          {items.map((it) => (
+            <AddedItemRow key={it.id} item={it} onRemove={removeItem} />
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between text-sm text-gray-600">
+        <div>
+          {total} added • {counts.file} file{counts.file === 1 ? '' : 's'}, {counts.url} link{counts.url === 1 ? '' : 's'}, {counts.note} note{counts.note === 1 ? '' : 's'}
+        </div>
+        <div className="flex gap-2">
+          <Button variant="secondary" onClick={clearAll} disabled={total === 0 && !intent}>
+            Clear All
+          </Button>
+          <Button onClick={generate} disabled={total === 0 && intent.trim() === ''}>
+            Generate Basket
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/web/components/create/PreviewPanel.tsx
+++ b/web/components/create/PreviewPanel.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { AddedItem, CreateState } from './useCreatePageMachine';
+import { ProgressRibbon } from './ProgressRibbon';
+
+interface Props {
+  intent: string;
+  items: AddedItem[];
+  state: CreateState;
+  progress: number;
+}
+
+export function PreviewPanel({ intent, items, state, progress }: Props) {
+  const titleSuggestion = intent || items[0]?.name || 'Proposed basket';
+  const errorItems = items.filter((i) => i.status === 'error');
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="font-medium mb-1">Proposed basket</h3>
+        <div className="border rounded p-2 text-sm" data-testid="title-suggestion">{titleSuggestion}</div>
+      </div>
+      <div>
+        <h3 className="font-medium mb-1">Draft summary</h3>
+        <div className="border rounded p-4 text-sm text-gray-500">We’ll auto-generate this after upload</div>
+      </div>
+      <div>
+        <h3 className="font-medium mb-1">First insights</h3>
+        <div className="border rounded p-4 text-sm text-gray-500">We’ll auto-generate this after upload</div>
+      </div>
+      <ProgressRibbon progress={progress} state={state} fileCount={items.filter(i=>i.kind==='file').length} />
+      {errorItems.length > 0 && (
+        <div className="text-sm text-yellow-600">⚠︎ {errorItems.length} item{errorItems.length>1?'s':''} needs attention</div>
+      )}
+    </div>
+  );
+}
+

--- a/web/components/create/ProgressRibbon.tsx
+++ b/web/components/create/ProgressRibbon.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { CreateState } from './useCreatePageMachine';
+
+interface Props {
+  progress: number;
+  state: CreateState;
+  fileCount: number;
+}
+
+export function ProgressRibbon({ progress, state, fileCount }: Props) {
+  const steps = ['Uploading', 'Parsing', 'Dumps', 'Scaffolding'];
+  const activeIndex = Math.min(Math.floor(progress / 25), steps.length - 1);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-2 text-xs">
+        {steps.map((step, i) => (
+          <div
+            key={step}
+            className={`px-2 py-1 rounded-full border ${
+              i <= activeIndex ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-600'
+            }`}
+          >
+            {step}
+          </div>
+        ))}
+      </div>
+      <div className="w-full bg-gray-200 h-1 rounded">
+        <div className="bg-blue-600 h-1 rounded" style={{ width: `${progress}%` }} />
+      </div>
+      <div className="text-xs text-gray-500">
+        {state === 'EMPTY' || state === 'COLLECTING'
+          ? 'Waiting to start…'
+          : `Parsing ${fileCount} file${fileCount === 1 ? '' : 's'} • Creating raw dumps…`}
+      </div>
+    </div>
+  );
+}
+

--- a/web/components/create/useCreatePageMachine.ts
+++ b/web/components/create/useCreatePageMachine.ts
@@ -1,0 +1,223 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { apiClient } from '@/lib/api/client';
+import { uploadFile } from '@/lib/uploadFile';
+import { sanitizeFilename } from '@/lib/utils/sanitizeFilename';
+import { dlog } from '@/lib/dev/log';
+
+export type CreateState =
+  | 'EMPTY'
+  | 'COLLECTING'
+  | 'SUBMITTED'
+  | 'PROCESSING'
+  | 'PROCESSING_WITH_WARNINGS'
+  | 'PREVIEW_READY'
+  | 'COMPLETE'
+  | 'ERROR';
+
+export interface AddedItem {
+  id: string;
+  kind: 'file' | 'url' | 'note';
+  name: string;
+  size?: number;
+  file?: File;
+  url?: string;
+  text?: string;
+  status: 'queued' | 'uploading' | 'uploaded' | 'parsed' | 'fetched' | 'ready' | 'error';
+  error?: string;
+}
+
+export function useCreatePageMachine() {
+  const router = useRouter();
+  const [state, setState] = useState<CreateState>('EMPTY');
+  const [intent, setIntent] = useState('');
+  const [items, setItems] = useState<AddedItem[]>([]);
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    dlog('telemetry', { event: 'create_viewed' });
+  }, []);
+
+  // recompute state when intent/items change
+  const recompute = (nextIntent: string, nextItems: AddedItem[]) => {
+    if (nextIntent.trim() !== '' || nextItems.length > 0) {
+      setState((prev) => (prev === 'EMPTY' ? 'COLLECTING' : prev));
+    } else {
+      setState('EMPTY');
+    }
+  };
+
+  const setIntentWrapper = (v: string) => {
+    setIntent(v);
+    recompute(v, items);
+  };
+
+  const addFiles = (files: File[]) => {
+    const newItems: AddedItem[] = files.map((f) => ({
+      id: crypto.randomUUID(),
+      kind: 'file',
+      name: f.name,
+      size: f.size,
+      file: f,
+      status: 'queued',
+    }));
+    const merged = [...items, ...newItems];
+    setItems(merged);
+    recompute(intent, merged);
+    dlog('telemetry', { event: 'create_added_item', type: 'file' });
+  };
+
+  const addUrl = (url: string) => {
+    const newItem: AddedItem = {
+      id: crypto.randomUUID(),
+      kind: 'url',
+      name: url,
+      url,
+      status: 'queued',
+    };
+    const merged = [...items, newItem];
+    setItems(merged);
+    recompute(intent, merged);
+    dlog('telemetry', { event: 'create_added_item', type: 'url' });
+  };
+
+  const addNote = (text: string) => {
+    const newItem: AddedItem = {
+      id: crypto.randomUUID(),
+      kind: 'note',
+      name: text.slice(0, 30),
+      text,
+      status: 'ready',
+    };
+    const merged = [...items, newItem];
+    setItems(merged);
+    recompute(intent, merged);
+    dlog('telemetry', { event: 'create_added_item', type: 'note' });
+  };
+
+  const removeItem = (id: string) => {
+    const filtered = items.filter((it) => it.id !== id);
+    setItems(filtered);
+    recompute(intent, filtered);
+  };
+
+  const clearAll = () => {
+    setItems([]);
+    setIntent('');
+    setState('EMPTY');
+  };
+
+  // pseudo progress
+  useEffect(() => {
+    if (state === 'SUBMITTED' || state === 'PROCESSING') {
+      const interval = setInterval(() => {
+        setProgress((p) => (p < 90 ? p + 5 : p));
+      }, 500);
+      return () => clearInterval(interval);
+    }
+  }, [state]);
+
+  const generate = async () => {
+    if (items.length === 0 && intent.trim() === '') return;
+    if (state === 'SUBMITTED' || state === 'PROCESSING') return;
+
+    dlog('telemetry', { event: 'create_generate_clicked' });
+    setState('SUBMITTED');
+    setProgress(5);
+
+    try {
+      const basket = await apiClient.request<{ id: string }>(
+        '/api/baskets',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            name: intent || items[0]?.name || 'New Basket',
+            description: intent,
+            status: 'INIT',
+          }),
+        }
+      );
+
+      setState('PROCESSING');
+
+      const results = await Promise.all(
+        items.map(async (item) => {
+          try {
+            if (item.kind === 'file' && item.file) {
+              item.status = 'uploading';
+              const sanitized = sanitizeFilename(item.file.name);
+              const url = await uploadFile(
+                item.file,
+                `ingest/${sanitized}`
+              );
+              item.status = 'uploaded';
+              await apiClient.request('/api/dumps/new', {
+                method: 'POST',
+                body: JSON.stringify({
+                  basket_id: basket.id,
+                  text_dump: item.name,
+                  file_urls: [url],
+                }),
+              });
+              item.status = 'parsed';
+            } else if (item.kind === 'url') {
+              await apiClient.request('/api/dumps/new', {
+                method: 'POST',
+                body: JSON.stringify({
+                  basket_id: basket.id,
+                  text_dump: item.url,
+                }),
+              });
+              item.status = 'fetched';
+            } else if (item.kind === 'note') {
+              await apiClient.request('/api/dumps/new', {
+                method: 'POST',
+                body: JSON.stringify({
+                  basket_id: basket.id,
+                  text_dump: item.text,
+                }),
+              });
+              item.status = 'ready';
+            }
+            return { ok: true };
+          } catch (e: any) {
+            item.status = 'error';
+            item.error = e?.message || 'Unknown error';
+            return { ok: false };
+          }
+        })
+      );
+
+      const anyFail = results.some((r) => !r.ok);
+      setState(anyFail ? 'PROCESSING_WITH_WARNINGS' : 'PROCESSING');
+      setProgress(95);
+
+      dlog('telemetry', { event: 'create_complete' });
+
+      setState(anyFail ? 'PROCESSING_WITH_WARNINGS' : 'COMPLETE');
+      setProgress(100);
+
+      router.push(`/baskets/${basket.id}/work`);
+    } catch (e) {
+      console.error('❌ Basket creation failed:', e);
+      setState('ERROR');
+    }
+  };
+
+  return {
+    state,
+    intent,
+    items,
+    progress,
+    setIntent: setIntentWrapper,
+    addFiles,
+    addUrl,
+    addNote,
+    removeItem,
+    clearAll,
+    generate,
+  };
+}
+


### PR DESCRIPTION
## Summary
- add two-pane create page using CaptureTray and PreviewPanel
- manage ingestion flow with useCreatePageMachine state machine and telemetry
- show progress ribbon and item status chips during basket generation

## Testing
- `npm test`
- `npm --prefix web run lint` *(fails: next: not found)*
- `npm run build:check` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bfcd6daa88329ab473fa225412390