### PR TITLE
Handle missing basket state data

### DIFF
--- a/web/app/baskets/[id]/dashboard/page.tsx
+++ b/web/app/baskets/[id]/dashboard/page.tsx
@@ -2,6 +2,7 @@ import StateSnapshot from "@/components/basket/StateSnapshot";
 import DocsList from "@/components/basket/DocsList";
 import NextMove from "@/components/basket/NextMove";
 import { getServerUrl } from "@/lib/utils";
+import { notFound } from "next/navigation";
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -16,8 +17,12 @@ export default async function DashboardPage({ params }: PageProps) {
     fetch(`${baseUrl}/api/baskets/${id}/proposals`, { cache: "no-store" }),
   ]);
 
+  if (!stateRes.ok) {
+    notFound();
+  }
+
   const state = await stateRes.json();
-  const docs = await docsRes.json();
+  const docs = docsRes.ok ? await docsRes.json() : { items: [] };
   const proposals = proposalsRes.ok ? await proposalsRes.json() : { items: [] };
 
   return (


### PR DESCRIPTION
## Summary
- avoid crashing baskets dashboard when state data is missing
- default to empty docs list when document fetch fails

## Testing
- `npm test`
- `npm run lint`
- `npm run build:check`


------
https://chatgpt.com/codex/tasks/task_e_68a271e3fe5083299e2c24aed204f8c9