### PR TITLE
fix auth exemption logic

### DIFF
--- a/api/src/app/agent_server.py
+++ b/api/src/app/agent_server.py
@@ -65,7 +65,11 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="RightNow Agent Server", lifespan=lifespan)
 
 # Require JWT auth on API routes
-app.add_middleware(AuthMiddleware, exempt_paths={"/", "/health/db"})
+app.add_middleware(
+    AuthMiddleware,
+    exempt_paths={"/", "/health/db", "/docs", "/openapi.json"},
+    exempt_prefixes={"/health"},
+)
 
 # Include routers
 routers = (


### PR DESCRIPTION
## Summary
- split auth middleware exemptions into exact paths vs prefixes to avoid catch-all '/'
- configure agent server middleware with distinct exact paths and health prefixes

## Testing
- `pre-commit run --files api/src/middleware/auth.py api/src/app/agent_server.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests', 'src.app.ingestion', 'fastapi', 'pydantic', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a29c9c28c48329ac074d13f920a963