### PR TITLE
fix: separate client layout to avoid server hook usage

### DIFF
--- a/web/app/baskets/[id]/layout.tsx
+++ b/web/app/baskets/[id]/layout.tsx
@@ -1,13 +1,11 @@
-import TopBar from "@/components/basket/TopBar";
-import BasketNav from "@/components/basket/BasketNav";
-import Guide from "@/components/basket/Guide";
-import React from "react";
+import type { ReactNode } from "react";
 import { cookies } from "next/headers";
 import { createServerComponentClient } from "@/lib/supabase/clients";
 import { ensureWorkspaceServer } from "@/lib/workspaces/ensureWorkspaceServer";
+import BasketLayoutClient from "@/components/basket/BasketLayoutClient";
 
 interface LayoutProps {
-  children: React.ReactNode;
+  children: ReactNode;
   params: Promise<{ id: string }>;
 }
 
@@ -37,36 +35,5 @@ export default async function BasketLayout({ children, params }: LayoutProps) {
     <BasketLayoutClient basketId={id} basketName={basketName}>
       {children}
     </BasketLayoutClient>
-  );
-}
-
-function BasketLayoutClient({
-  basketId,
-  basketName,
-  children,
-}: {
-  basketId: string;
-  basketName: string;
-  children: React.ReactNode;
-}) {
-  "use client";
-  const [showNav, setShowNav] = React.useState(() => {
-    if (typeof window === "undefined") return true;
-    return localStorage.getItem("basket-nav") !== "hidden";
-  });
-
-  React.useEffect(() => {
-    localStorage.setItem("basket-nav", showNav ? "show" : "hidden");
-  }, [showNav]);
-
-  return (
-    <div className="flex h-screen flex-col">
-      <TopBar title={basketName} onToggleNav={() => setShowNav((s) => !s)} />
-      <div className="flex flex-1 overflow-hidden">
-        {showNav && <BasketNav basketId={basketId} />}
-        <div className="flex-1 overflow-y-auto p-4">{children}</div>
-        <Guide />
-      </div>
-    </div>
   );
 }

--- a/web/components/basket/BasketLayoutClient.tsx
+++ b/web/components/basket/BasketLayoutClient.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from "react";
+import TopBar from "@/components/basket/TopBar";
+import BasketNav from "@/components/basket/BasketNav";
+import Guide from "@/components/basket/Guide";
+
+export default function BasketLayoutClient({
+  basketId,
+  basketName,
+  children,
+}: {
+  basketId: string;
+  basketName: string;
+  children: React.ReactNode;
+}) {
+  const [showNav, setShowNav] = React.useState(() => {
+    if (typeof window === "undefined") return true;
+    return localStorage.getItem("basket-nav") !== "hidden";
+  });
+
+  React.useEffect(() => {
+    localStorage.setItem("basket-nav", showNav ? "show" : "hidden");
+  }, [showNav]);
+
+  return (
+    <div className="flex h-screen flex-col">
+      <TopBar title={basketName} onToggleNav={() => setShowNav((s) => !s)} />
+      <div className="flex flex-1 overflow-hidden">
+        {showNav && <BasketNav basketId={basketId} />}
+        <div className="flex-1 overflow-y-auto p-4">{children}</div>
+        <Guide />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- move BasketLayoutClient into its own client component
- import BasketLayoutClient in basket layout to prevent server-side useState error

## Testing
- `npm test`
- `npm --prefix web run build`

------
https://chatgpt.com/codex/tasks/task_e_68a321c4ddb88329a2ba4f265fcecf2a