### PR TITLE
fix: remove undefined processingResults

### DIFF
--- a/web/app/api/substrate/add-context/route.ts
+++ b/web/app/api/substrate/add-context/route.ts
@@ -84,14 +84,18 @@ export async function POST(request: NextRequest) {
     }
     
     // Build response
+    // Since this simplified route only consolidates content and creates a dump
+    // (without running the original universal processor), return defaults for
+    // the processing statistics. This avoids referencing the removed
+    // `processingResults` variable which caused the build to fail.
     const result: AddContextResult = {
       success: true,
       rawDumpId: dump.id,
       processingResults: {
         contentProcessed: content.length,
-        insights: processingResults?.results ? 'Generated' : 'None',
+        insights: 'None',
         filesProcessed: fileUrls.length,
-        processingQuality: processingResults?.results?.metadata?.averageQuality || 'N/A',
+        processingQuality: 'N/A',
       },
     };
 


### PR DESCRIPTION
## Summary
- avoid referencing removed processing results in add-context API

## Testing
- `npm test`
- `npm run lint`
- `npm --prefix web run lint`
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_68a584e65fe08329880b116de48bce3a