### PR TITLE
feat: harden dump ingestion route

### DIFF
--- a/web/app/api/dumps/new/route.ts
+++ b/web/app/api/dumps/new/route.ts
@@ -7,36 +7,42 @@ import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { getAuthenticatedUser } from "@/lib/auth/getAuthenticatedUser";
 import { z } from "zod";
 
-const BaseSchema = z.object({
+function normalize(body: any) {
+  const b = body ?? {};
+  const n = (v: any) => (v === null || v === undefined ? undefined : v);
+
+  return {
+    basket_id:      b.basket_id ?? b.basketId,
+    text_dump:      n(b.text_dump ?? b.text),
+    file_urls:      n(
+                      Array.isArray(b.file_urls) ? b.file_urls :
+                      Array.isArray(b.fileUrls)  ? b.fileUrls  :
+                      typeof b.file_url === "string" ? [b.file_url] :
+                      typeof b.fileUrl === "string"  ? [b.fileUrl]  :
+                      undefined
+                    ),
+    source_meta:    n(b.source_meta ?? b.meta),
+    ingest_trace_id:n(b.ingest_trace_id ?? b.ingestTraceId),
+    dump_request_id:b.dump_request_id ?? b.dumpRequestId ?? b.request_id,
+  };
+}
+
+const Schema = z.object({
   basket_id: z.string().uuid(),
-  text_dump: z.string().min(1).optional(),
-  file_urls: z.array(z.string().url()).optional(),
+  text_dump: z.string().trim().min(1).optional(),        // optional but if present must be non-empty after trim
+  file_urls: z.array(z.string().url()).nonempty().optional(), // optional but if present must have at least one
   source_meta: z.record(z.any()).optional(),
   ingest_trace_id: z.string().uuid().optional(),
-  dump_request_id: z.string().uuid(),
-});
-
-const InputSchema = BaseSchema.refine(
-  (d) => (d.text_dump && d.text_dump.trim().length > 0) || (d.file_urls && d.file_urls.length > 0),
-  { message: "Provide text_dump or file_urls" }
+  dump_request_id: z.string().uuid(),                     // required
+}).refine(
+  (d) => Boolean(d.text_dump) || Boolean(d.file_urls?.length),
+  { message: "Provide non-empty text_dump or one/more file_urls" }
 );
-
-function normalizePayload(raw: any) {
-  if (raw && typeof raw === 'object') {
-    if (raw.text && !raw.text_dump) raw.text_dump = raw.text;
-    if (raw.fileUrl) raw.file_urls = [raw.fileUrl];
-    if (raw.fileUrls && !raw.file_urls)
-      raw.file_urls = Array.isArray(raw.fileUrls) ? raw.fileUrls : [raw.fileUrls];
-    if (raw.dumpRequestId && !raw.dump_request_id) raw.dump_request_id = raw.dumpRequestId;
-    if (raw.ingestTraceId && !raw.ingest_trace_id) raw.ingest_trace_id = raw.ingestTraceId;
-  }
-  return raw;
-}
 
 export async function POST(req: Request) {
   try {
-    const raw = normalizePayload(await req.json().catch(() => null));
-    const parsed = InputSchema.safeParse(raw);
+    const raw = await req.json().catch(() => null);
+    const parsed = Schema.safeParse(normalize(raw));
     if (!parsed.success) {
       return Response.json({ error: "Invalid request", details: parsed.error.flatten() }, { status: 422 });
     }
@@ -45,6 +51,7 @@ export async function POST(req: Request) {
     const supabase = createRouteHandlerClient({ cookies });
     const { userId } = await getAuthenticatedUser(supabase);
 
+    // Resolve basket + workspace
     const { data: basket, error: bErr } = await supabase
       .from("baskets")
       .select("id, workspace_id")
@@ -53,6 +60,7 @@ export async function POST(req: Request) {
     if (bErr) return Response.json({ error: `Basket lookup failed: ${bErr.message}` }, { status: 400 });
     if (!basket) return Response.json({ error: "Basket not found" }, { status: 404 });
 
+    // Verify membership (defense-in-depth; RLS still applies)
     const { data: membership, error: mErr } = await supabase
       .from("workspace_memberships")
       .select("id")
@@ -62,6 +70,7 @@ export async function POST(req: Request) {
     if (mErr) return Response.json({ error: `Membership check failed: ${mErr.message}` }, { status: 400 });
     if (!membership) return Response.json({ error: "Forbidden" }, { status: 403 });
 
+    // Idempotent RPC; DB trigger emits 'dump'
     const { data, error: rpcErr } = await supabase.rpc("fn_ingest_dumps", {
       p_workspace_id: basket.workspace_id,
       p_basket_id: basket_id,
@@ -75,15 +84,14 @@ export async function POST(req: Request) {
         },
       ],
     });
+
     if (rpcErr) {
       const code = rpcErr.code === "23505" ? 409 : 500;
       return Response.json({ error: "Ingest failed", details: rpcErr.message }, { status: code });
     }
 
     const dump_id = Array.isArray(data) && data[0]?.dump_id;
-    if (!dump_id) {
-      return Response.json({ error: "Ingest returned no dump_id" }, { status: 500 });
-    }
+    if (!dump_id) return Response.json({ error: "Ingest returned no dump_id" }, { status: 500 });
 
     return Response.json({ dump_id }, { status: 201 });
   } catch (e: any) {


### PR DESCRIPTION
## Summary
- harden /api/dumps/new POST handler: normalize legacy keys, coerce nulls, validate and call `fn_ingest_dumps`
- polish DumpBarPanel with bottom-right anchor, height cap, and stricter upload checks

## Testing
- `rg -n --hidden -S "lib/baskets/createDump|dumpApi|UnifiedIngest|DumpBarHero|MemoryCapture" web || true`
- `npm test && npm run lint`
- `curl -s -o - -w "%{http_code}\n" -X POST -H "Content-Type: application/json" -d '{"basket_id":"00000000-0000-0000-0000-000000000000","text_dump":"hi","dump_request_id":"11111111-1111-1111-1111-111111111111","file_urls":null}' http://localhost:3000/api/dumps/new`

------
https://chatgpt.com/codex/tasks/task_e_68a80e1ddfa08329b8ad69abe1883559