### PR TITLE
Pre-truncate long memory pastes in onboarding endpoint

### DIFF
--- a/shared/contracts/onboarding.ts
+++ b/shared/contracts/onboarding.ts
@@ -1,11 +1,18 @@
 import { z } from "zod";
 
+export const MEMORY_PASTE_MAX = 20_000;
+
 export const OnboardingSubmitSchema = z.object({
   basket_id: z.string().uuid(),
   name: z.string().min(1).max(60),
   tension: z.string().min(1).max(1200),
   aspiration: z.string().min(1).max(1200),
-  memory_paste: z.string().max(20000).optional(),
+  memory_paste: z
+    .preprocess(
+      (v) => (typeof v === "string" ? v.slice(0, MEMORY_PASTE_MAX) : v),
+      z.string().max(MEMORY_PASTE_MAX)
+    )
+    .optional(),
   create_profile_document: z.boolean().default(true),
 });
 export type OnboardingSubmitDTO = z.infer<typeof OnboardingSubmitSchema>;

--- a/web/app/api/onboarding/complete/route.ts
+++ b/web/app/api/onboarding/complete/route.ts
@@ -7,12 +7,19 @@ import { randomUUID } from 'crypto';
 import { createServerSupabaseClient } from '@/lib/supabase/server';
 import { getAuthenticatedUser } from '@/lib/auth/getAuthenticatedUser';
 import { ensureWorkspaceForUser } from '@/lib/workspaces/ensureWorkspaceForUser';
-import { OnboardingSubmitSchema, OnboardingResultSchema } from '@shared/contracts/onboarding';
+import {
+  OnboardingSubmitSchema,
+  OnboardingResultSchema,
+  MEMORY_PASTE_MAX,
+} from '@shared/contracts/onboarding';
 import { createGenesisProfileDocument } from '@/lib/server/onboarding';
 
 export async function POST(req: Request) {
   try {
     const raw = await req.json().catch(() => null);
+    if (typeof raw?.memory_paste === 'string' && raw.memory_paste.length > MEMORY_PASTE_MAX) {
+      raw.memory_paste = raw.memory_paste.slice(0, MEMORY_PASTE_MAX);
+    }
     const parsed = OnboardingSubmitSchema.safeParse(raw);
     if (!parsed.success) {
       return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 422 });


### PR DESCRIPTION
## Summary
- Export `MEMORY_PASTE_MAX` and preprocess `memory_paste` in shared onboarding contract
- Belt-and-suspenders truncation of `memory_paste` before schema parsing in onboarding complete API

## Testing
- `npm test`
- `npm run contracts:check`
- `npm run build:check` *(fails: Missing NEXT_PUBLIC_API_BASE_URL in environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4420538483298224ca8b4e42d195